### PR TITLE
321 user roles are cleared during patch update

### DIFF
--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/AbstractBaseUser.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/AbstractBaseUser.java
@@ -74,6 +74,10 @@ public abstract class AbstractBaseUser<ID extends Serializable> extends Abstract
 
   @NotNull
   @ManyToMany(fetch = FetchType.EAGER)
+  @JoinTable(
+      name = "FW_USER_ROLES",
+      joinColumns = @JoinColumn(name = "user_id"),
+      inverseJoinColumns = @JoinColumn(name = "roles_name"))
   @Builder.Default
   private Set<Role> roles = new HashSet<>();
 

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/AbstractBaseUser.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/AbstractBaseUser.java
@@ -74,10 +74,6 @@ public abstract class AbstractBaseUser<ID extends Serializable> extends Abstract
 
   @NotNull
   @ManyToMany(fetch = FetchType.EAGER)
-  @JoinTable(
-      name = "FW_USER_ROLES",
-      joinColumns = @JoinColumn(name = "user_id"),
-      inverseJoinColumns = @JoinColumn(name = "roles_name"))
   @Builder.Default
   private Set<Role> roles = new HashSet<>();
 

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/AbstractUserService.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/AbstractUserService.java
@@ -236,9 +236,25 @@ public abstract class AbstractUserService<
                         .map(roleService::getByName)
                         .filter(Objects::nonNull)
                         .collect(Collectors.toSet()));
+              } else if (objectList.iterator().next() instanceof Map) {
+                updates.put(
+                    "roles",
+                    objectList.stream()
+                        .map(Map.class::cast)
+                        .map(roleMap -> roleMap.get("name"))
+                        .filter(roleName -> roleName instanceof String)
+                        .map(String.class::cast)
+                        .map(roleService::getByName)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toSet()));
               } else if (objectList.iterator().next() instanceof Role) {
                 updates.put(
-                    "roles", objectList.stream().map(Role.class::cast).collect(Collectors.toSet()));
+                    "roles",
+                    objectList.stream()
+                        .map(Role.class::cast)
+                        .map(role -> roleService.getByName(role.getName()))
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toSet()));
               }
             });
 

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/AbstractUserService.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/AbstractUserService.java
@@ -248,11 +248,6 @@ public abstract class AbstractUserService<
         userToUpdate,
         Optional.ofNullable(updates.get("password")).map(Object::toString).orElse(null));
 
-    Set<Role> roles = userToUpdate.getRoles();
-    userToUpdate.setRoles(new HashSet<>());
-    userToUpdate = repository.save(userToUpdate);
-    userToUpdate.setRoles(roles);
-
     return userToUpdate;
   }
 

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/service/LongUserServiceTest.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/service/LongUserServiceTest.java
@@ -485,7 +485,7 @@ class LongUserServiceTest {
       assertNull(savedUser.getPassword());
 
       verify(userRepositoryMock, times(2)).findById(anyLong());
-      verify(userRepositoryMock, times(2)).save(any(TestLongUser.class));
+      verify(userRepositoryMock, times(1)).save(any(TestLongUser.class));
       verifyNoMoreInteractions(userRepositoryMock);
     }
   }
@@ -762,7 +762,7 @@ class LongUserServiceTest {
       assertThat(result.getLocale()).isEqualTo(NEW_LOCALE);
       assertThat(result.getPassword()).isEqualTo(TEST_PASSWORD_HASH);
 
-      verify(userRepositoryMock, times(2)).save(any(TestLongUser.class));
+      verify(userRepositoryMock, times(1)).save(any(TestLongUser.class));
       verify(userRepositoryMock, times(2)).findById(anyLong());
       verifyNoMoreInteractions(userRepositoryMock);
     }

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/service/UUIDUserServiceTest.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/service/UUIDUserServiceTest.java
@@ -496,7 +496,7 @@ class UUIDUserServiceTest {
       assertNull(savedUser.getPassword());
 
       verify(userRepositoryMock, times(2)).findById(any());
-      verify(userRepositoryMock, times(2)).save(any(TestUUIDUser.class));
+      verify(userRepositoryMock, times(1)).save(any(TestUUIDUser.class));
       verifyNoMoreInteractions(userRepositoryMock);
     }
   }
@@ -774,7 +774,7 @@ class UUIDUserServiceTest {
       assertThat(result.getLocale()).isEqualTo(NEW_LOCALE);
       assertThat(result.getPassword()).isEqualTo(TEST_PASSWORD_HASH);
 
-      verify(userRepositoryMock, times(2)).save(any(TestUUIDUser.class));
+      verify(userRepositoryMock, times(1)).save(any(TestUUIDUser.class));
       verify(userRepositoryMock, times(2)).findById(any());
       verifyNoMoreInteractions(userRepositoryMock);
     }

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/service/UUIDUserServiceTest.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/service/UUIDUserServiceTest.java
@@ -505,7 +505,8 @@ class UUIDUserServiceTest {
   class UpdateUserFields {
 
     private final TestUUIDUser testUser = TestUUIDUser.builder().email("Don´t care!").build();
-
+    private final Role adminRole = Role.builder().name("ADMIN").description("TEST ADMIN").build();
+    private final Role userRole = Role.builder().name("USER").description("TEST USER").build();
     private Map<String, Object> testMap;
 
     @BeforeEach
@@ -563,6 +564,195 @@ class UUIDUserServiceTest {
 
                 return toSave;
               });
+
+      assertDoesNotThrow(() -> testSubject.patch(testId, testMap));
+    }
+
+    @Test
+    void updateAddRolesByNameSuccessful() {
+      List<String> testRoleAuthorities = List.of(adminRole.getName(), userRole.getName());
+
+      testMap.put("roles", testRoleAuthorities);
+
+      when(userRepositoryMock.findById(testId)).thenReturn(Optional.of(testUser));
+      when(roleServiceMock.getByName(adminRole.getName())).thenReturn(adminRole);
+      when(roleServiceMock.getByName(userRole.getName())).thenReturn(userRole);
+
+      when(userRepositoryMock.save(testUser))
+          .thenAnswer(
+              invocation -> {
+                TestUUIDUser toSave = invocation.getArgument(0);
+
+                assertThat(toSave.getRoles()).containsOnly(adminRole, userRole);
+
+                return toSave;
+              });
+
+      assertThat(testUser.getRoles()).isEmpty();
+
+      assertDoesNotThrow(() -> testSubject.patch(testId, testMap));
+    }
+
+    @Test
+    void updateRemoveRolesByNameSuccessful() {
+      final Role testRoleToKeep = adminRole;
+      final Role testRoleToRemove = userRole;
+
+      List<String> testRolesToKeep = List.of(testRoleToKeep.getName());
+      testMap.put("roles", testRolesToKeep);
+
+      testUser.getRoles().add(testRoleToKeep);
+      testUser.getRoles().add(testRoleToRemove);
+
+      when(roleServiceMock.getByName(testRoleToKeep.getName())).thenReturn(testRoleToKeep);
+
+      when(userRepositoryMock.findById(testId)).thenReturn(Optional.of(testUser));
+      when(userRepositoryMock.save(testUser))
+          .thenAnswer(
+              invocation -> {
+                TestUUIDUser toSave = invocation.getArgument(0);
+
+                assertThat(toSave.getRoles()).containsOnly(testRoleToKeep);
+
+                return toSave;
+              });
+
+      assertThat(testUser.getRoles()).isNotEmpty();
+
+      assertDoesNotThrow(() -> testSubject.patch(testId, testMap));
+      verify(roleServiceMock, times(0)).getByName(testRoleToRemove.getName());
+    }
+
+    @Test
+    void updateAddRolesByRoleSuccessful() {
+      List<Role> adminRoleAuthorities = List.of(adminRole, userRole);
+
+      testMap.put("roles", adminRoleAuthorities);
+
+      when(userRepositoryMock.findById(testId)).thenReturn(Optional.of(testUser));
+      when(roleServiceMock.getByName(adminRole.getName())).thenReturn(adminRole);
+      when(roleServiceMock.getByName(userRole.getName())).thenReturn(userRole);
+
+      when(userRepositoryMock.save(testUser))
+          .thenAnswer(
+              invocation -> {
+                TestUUIDUser toSave = invocation.getArgument(0);
+
+                assertThat(toSave.getRoles()).containsOnly(adminRole, userRole);
+
+                return toSave;
+              });
+
+      assertThat(testUser.getRoles()).isEmpty();
+
+      assertDoesNotThrow(() -> testSubject.patch(testId, testMap));
+    }
+
+    @Test
+    void updateRemoveRolesByRoleSuccessful() {
+      final Role testRoleToKeep = adminRole;
+      final Role testRoleToRemove = userRole;
+
+      List<Role> testRolesToKeep = List.of(testRoleToKeep);
+      testMap.put("roles", testRolesToKeep);
+
+      testUser.getRoles().add(testRoleToKeep);
+      testUser.getRoles().add(testRoleToRemove);
+
+      when(roleServiceMock.getByName(testRoleToKeep.getName())).thenReturn(testRoleToKeep);
+
+      when(userRepositoryMock.findById(testId)).thenReturn(Optional.of(testUser));
+      when(userRepositoryMock.save(testUser))
+          .thenAnswer(
+              invocation -> {
+                TestUUIDUser toSave = invocation.getArgument(0);
+
+                assertThat(toSave.getRoles()).containsOnly(testRoleToKeep);
+
+                return toSave;
+              });
+
+      assertThat(testUser.getRoles()).isNotEmpty();
+
+      assertDoesNotThrow(() -> testSubject.patch(testId, testMap));
+      verify(roleServiceMock, times(0)).getByName(testRoleToRemove.getName());
+    }
+
+    @Test
+    void updateAddRolesByMapSuccessful() {
+      List<Map<String, String>> adminRoleAuthorities =
+          List.of(Map.of("name", adminRole.getName()), Map.of("name", userRole.getName()));
+
+      testMap.put("roles", adminRoleAuthorities);
+
+      when(userRepositoryMock.findById(testId)).thenReturn(Optional.of(testUser));
+      when(roleServiceMock.getByName(adminRole.getName())).thenReturn(adminRole);
+      when(roleServiceMock.getByName(userRole.getName())).thenReturn(userRole);
+
+      when(userRepositoryMock.save(testUser))
+          .thenAnswer(
+              invocation -> {
+                TestUUIDUser toSave = invocation.getArgument(0);
+
+                assertThat(toSave.getRoles()).containsOnly(adminRole, userRole);
+
+                return toSave;
+              });
+
+      assertThat(testUser.getRoles()).isEmpty();
+
+      assertDoesNotThrow(() -> testSubject.patch(testId, testMap));
+    }
+
+    @Test
+    void updateRemoveRolesByMapSuccessful() {
+      final Role testRoleToKeep = adminRole;
+      final Role testRoleToRemove = userRole;
+
+      List<Map<String, String>> testRolesToKeep = List.of(Map.of("name", testRoleToKeep.getName()));
+      testMap.put("roles", testRolesToKeep);
+
+      testUser.getRoles().add(testRoleToKeep);
+      testUser.getRoles().add(testRoleToRemove);
+
+      when(roleServiceMock.getByName(testRoleToKeep.getName())).thenReturn(testRoleToKeep);
+
+      when(userRepositoryMock.findById(testId)).thenReturn(Optional.of(testUser));
+      when(userRepositoryMock.save(testUser))
+          .thenAnswer(
+              invocation -> {
+                TestUUIDUser toSave = invocation.getArgument(0);
+
+                assertThat(toSave.getRoles()).containsOnly(testRoleToKeep);
+
+                return toSave;
+              });
+
+      assertThat(testUser.getRoles()).isNotEmpty();
+
+      assertDoesNotThrow(() -> testSubject.patch(testId, testMap));
+      verify(roleServiceMock, times(0)).getByName(testRoleToRemove.getName());
+    }
+
+    @Test
+    void updateRemoveAllRolesSuccessful() {
+      testUser.getRoles().add(adminRole);
+      testUser.getRoles().add(userRole);
+
+      testMap.put("roles", Collections.emptyList());
+
+      when(userRepositoryMock.findById(testId)).thenReturn(Optional.of(testUser));
+      when(userRepositoryMock.save(testUser))
+          .thenAnswer(
+              invocation -> {
+                TestUUIDUser toSave = invocation.getArgument(0);
+
+                assertThat(toSave.getRoles()).isEmpty();
+
+                return toSave;
+              });
+
+      assertThat(testUser.getRoles()).isNotEmpty();
 
       assertDoesNotThrow(() -> testSubject.patch(testId, testMap));
     }

--- a/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/UserControllerIntegrationTest.java
+++ b/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/UserControllerIntegrationTest.java
@@ -196,7 +196,7 @@ class UserControllerIntegrationTest {
     String newFirstName = "Peter";
     HashMap<String, Object> content = new HashMap<>();
     List<String> expectedRolesContent =
-            new ArrayList<>(testUser.getRoles().stream().map(Role::getName).toList());
+        new ArrayList<>(testUser.getRoles().stream().map(Role::getName).toList());
     expectedRolesContent.add("ADMIN");
 
     content.put("firstName", newFirstName);
@@ -219,8 +219,10 @@ class UserControllerIntegrationTest {
         .isNotEqualTo(content.get("source"));
     assertThat(user.get().getRoles().size()).isEqualTo(expectedRolesContent.size());
     assertThat(
-        user.get().getRoles().stream()
-            .allMatch(postUpdateRole -> expectedRolesContent.contains(postUpdateRole.getName()))).isTrue();
+            user.get().getRoles().stream()
+                .allMatch(
+                    postUpdateRole -> expectedRolesContent.contains(postUpdateRole.getName())))
+        .isTrue();
   }
 
   @Test

--- a/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/UserControllerIntegrationTest.java
+++ b/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/UserControllerIntegrationTest.java
@@ -192,10 +192,16 @@ class UserControllerIntegrationTest {
   @Test
   void checkUserControllerPatch() throws Exception {
     TestUser testUser = randomUser;
+    checkUserControllerFilterByRole();
     String newFirstName = "Peter";
-    HashMap<String, String> content = new HashMap<>();
+    HashMap<String, Object> content = new HashMap<>();
+    List<String> expectedRolesContent =
+            new ArrayList<>(testUser.getRoles().stream().map(Role::getName).toList());
+    expectedRolesContent.add("ADMIN");
+
     content.put("firstName", newFirstName);
     content.put("source", "notgonnahappen");
+    content.put("roles", expectedRolesContent);
 
     mockMvc
         .perform(
@@ -211,6 +217,10 @@ class UserControllerIntegrationTest {
     assertThat(user.get().getSource())
         .isEqualTo(testUser.getSource())
         .isNotEqualTo(content.get("source"));
+    assertThat(user.get().getRoles().size()).isEqualTo(expectedRolesContent.size());
+    assertThat(
+        user.get().getRoles().stream()
+            .allMatch(postUpdateRole -> expectedRolesContent.contains(postUpdateRole.getName()))).isTrue();
   }
 
   @Test


### PR DESCRIPTION
To prevent clearing all `Roles` of a `User` during a `PATCH` update, the `Role` are now processes in one of three ways:

- as simple `List<String` of given `Role` names
- as `List<Map<String, String`, where each entry is a `Role` representation
- as `List<Role>` for backwards compatibility

In each way, the `Role` is freshly fetched from the `RoleService` to prevent the occurrence of `DataIntegrityViolationException`