### PR TITLE
feat(auth): use correct JWT provider in filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Version `_________`
 
-- fix: prevent NullPointerException in OAuth2SuccessHandler/AbstractUserService if OAuth-mapped internal Role is not found
+- fix: Prevent NullPointerException in OAuth2SuccessHandler/AbstractUserService when OAuth-mapped internal role is not found
+- fix: Avoid calling DaoAuthenticationProvider on every request, which calls BCryptPasswordEncoder every time and causes performance problems.
 - upgraded org.springframework.boot:spring-boot-starter-parent from 3.3.0 to 3.3.1
 - upgraded io.jsonwebtoken:jjwt-api from 0.12.5 to 0.12.6
 - upgraded io.jsonwebtoken:jjwt-impl from 0.12.5 to 0.12.6

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/configuration/WebSecurityConfig.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/configuration/WebSecurityConfig.java
@@ -192,7 +192,6 @@ public class WebSecurityConfig<
               daoAuthenticationProvider(),
               oAuth2LoginAuthenticationProvider(),
               oidcAuthorizationCodeAuthenticationProvider(),
-              jwtAuthenticationProvider(),
               ldapAuthProvider());
     } else if (oAuth2ConfigProperties.isEnabled()) {
       // only oauth2 enabled
@@ -200,17 +199,13 @@ public class WebSecurityConfig<
           new ProviderManager(
               daoAuthenticationProvider(),
               oAuth2LoginAuthenticationProvider(),
-              oidcAuthorizationCodeAuthenticationProvider(),
-              jwtAuthenticationProvider());
+              oidcAuthorizationCodeAuthenticationProvider());
     } else if (ldapConfigProperties.isEnabled()) {
       // only ldap enabled
-      providerManager =
-          new ProviderManager(
-              daoAuthenticationProvider(), jwtAuthenticationProvider(), ldapAuthProvider());
+      providerManager = new ProviderManager(daoAuthenticationProvider(), ldapAuthProvider());
     } else {
       // only local login enabled
-      providerManager =
-          new ProviderManager(daoAuthenticationProvider(), jwtAuthenticationProvider());
+      providerManager = new ProviderManager(daoAuthenticationProvider());
     }
     providerManager.setAuthenticationEventPublisher(authenticationEventPublisher());
     return providerManager;
@@ -232,7 +227,7 @@ public class WebSecurityConfig<
     // only apply for routes requiring authentication
     final JwtTokenAuthenticationFilter filter =
         new JwtTokenAuthenticationFilter(DEFAULT_PROTECTED_URLS);
-    filter.setAuthenticationManager(authenticationManager());
+    filter.setAuthenticationManager(new ProviderManager(jwtAuthenticationProvider()));
     filter.setAuthenticationSuccessHandler(successHandler());
     return filter;
   }


### PR DESCRIPTION
- #502
- only use the `jwtAuthenticationProvider` in `JwtTokenAuthenticationFilter` to prevent unnecessary hashing and comparisons