### PR TITLE
feat(BaseUserSpec): email filter accepts partial emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Feature: `BasicRepresentation` can be used to create slim representations of entities. `BasicRepresentation` is very well suited for filling embedded objects or lists of objects in other representations.
 - Feature: Each Controller now has a `GET .../basic` endpoint that returns a List of BasicRepresentations of the entity. Filtering via Specifications is possible
+- Feature: `AbstractUserController` can now filter users by using a substring of an email.
 - upgraded io.sentry:sentry-spring-boot-starter-jakarta from 7.12.0 to 7.14.0
 - upgraded org.hibernate.orm:hibernate-jpamodelgen from 6.5.2.Final to 6.6.0.Final
 - upgraded commons-logging:commons-logging from 1.3.3 to 1.3.4

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/repository/specification/BaseUserSpec.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/repository/specification/BaseUserSpec.java
@@ -46,5 +46,12 @@ interface NameSpecBase<USER extends AbstractBaseUser<ID>, ID extends Serializabl
 interface EmailSpecBase<USER extends AbstractBaseUser<ID>, ID extends Serializable>
     extends BaseModelSpec<USER, ID> {}
 
+@Spec(
+    path = "email",
+    params = {"email", "user", "username"},
+    spec = LikeIgnoreCase.class)
+interface PartialEmailSpecBase<USER extends AbstractBaseUser<ID>, ID extends Serializable>
+    extends BaseModelSpec<USER, ID> {}
+
 public interface BaseUserSpec<USER extends AbstractBaseUser<ID>, ID extends Serializable>
-    extends RoleSpecBase<USER, ID>, NameSpecBase<USER, ID>, EmailSpecBase<USER, ID> {}
+    extends RoleSpecBase<USER, ID>, NameSpecBase<USER, ID>, PartialEmailSpecBase<USER, ID> {}

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/repository/specification/BaseUserSpec.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/repository/specification/BaseUserSpec.java
@@ -42,16 +42,9 @@ interface NameSpecBase<USER extends AbstractBaseUser<ID>, ID extends Serializabl
 @Spec(
     path = "email",
     params = {"email", "user", "username"},
-    spec = EqualIgnoreCase.class)
+    spec = LikeIgnoreCase.class)
 interface EmailSpecBase<USER extends AbstractBaseUser<ID>, ID extends Serializable>
     extends BaseModelSpec<USER, ID> {}
 
-@Spec(
-    path = "email",
-    params = {"email", "user", "username"},
-    spec = LikeIgnoreCase.class)
-interface PartialEmailSpecBase<USER extends AbstractBaseUser<ID>, ID extends Serializable>
-    extends BaseModelSpec<USER, ID> {}
-
 public interface BaseUserSpec<USER extends AbstractBaseUser<ID>, ID extends Serializable>
-    extends RoleSpecBase<USER, ID>, NameSpecBase<USER, ID>, PartialEmailSpecBase<USER, ID> {}
+    extends RoleSpecBase<USER, ID>, NameSpecBase<USER, ID>, EmailSpecBase<USER, ID> {}

--- a/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/UserControllerIntegrationTest.java
+++ b/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/UserControllerIntegrationTest.java
@@ -47,9 +47,7 @@ import jakarta.servlet.ServletContext;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -725,67 +723,82 @@ class UserControllerIntegrationTest {
         .andExpect(jsonPath("$.content.[0].id", is(user2.getId()), Long.class));
   }
 
-  @Test
-  void testFilterUsersByEmail() throws Exception {
-    final TestUser testUser1 =
-            testingUtils.createUser(
-                    testingUtils.getRandomUser().toBuilder().email("alan.turing@tech.de").build());
+  @Nested
+  @DisplayName("Filter Tests")
+  class FilterTest {
+    private TestUser testUser1;
+    private TestUser testUser2;
 
-    final TestUser testUser2 =
-            testingUtils.createUser(
-                    testingUtils.getRandomUser().toBuilder().email("steve.jobs@tech.de").build());
+    @BeforeEach
+    void setUpUsers() {
+      testUser1 =
+          testingUtils.createUser(
+              testingUtils.getRandomUser().toBuilder().email("alan.turing@tech.de").build());
 
-    // No filtering
+      testUser2 =
+          testingUtils.createUser(
+              testingUtils.getRandomUser().toBuilder().email("steve.jobs@tech.de").build());
+    }
 
-    mockMvc
-            .perform(
+    @Test
+    @DisplayName("Using no filter should return all elements")
+    void testNoFilter() throws Exception {
+      mockMvc
+          .perform(
               get("/v1/users")
-                      .contentType(MediaType.APPLICATION_JSON)
-                      .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenAdmin))
-            .andExpect(status().isOk())
-            // 1. admin user created during initialization
-            // 2. normal user created during initialization
-            // 3. random user created for tests (see setupSingle())
-            // 4. user1
-            // 5. user2
-            .andExpect(jsonPath("$.totalElements", Matchers.is(5)));
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenAdmin))
+          .andExpect(status().isOk())
+          // 1. admin user created during initialization
+          // 2. normal user created during initialization
+          // 3. random user created for tests (see setupSingle())
+          // 4. user1
+          // 5. user2
+          .andExpect(jsonPath("$.totalElements", Matchers.is(5)));
+    }
 
-    // Filter by full email
+    @Test
+    @DisplayName("Using full email should return a single user matching the email")
+    void testFullEmailFilter() throws Exception {
+      mockMvc
+          .perform(
+              get("/v1/users")
+                  .queryParam("email", testUser1.getEmail())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenAdmin))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.totalElements", Matchers.is(1)))
+          .andExpect(jsonPath("$.content[0].email", is(testUser1.getEmail()), String.class));
+    }
 
-    mockMvc
-            .perform(
-                    get("/v1/users")
-                            .queryParam("email", testUser1.getEmail())
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenAdmin))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.totalElements", Matchers.is(1)))
-            .andExpect(jsonPath("$.content[0].email", is(testUser1.getEmail()), String.class));
+    @Test
+    @DisplayName("Using almost full email should return a single user matching the partial email")
+    void testPartialEmailFilter() throws Exception {
+      mockMvc
+          .perform(
+              get("/v1/users")
+                  .queryParam("email", "alan.turing")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenAdmin))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.totalElements", Matchers.is(1)))
+          .andExpect(jsonPath("$.content[0].email", is(testUser1.getEmail()), String.class));
+    }
 
-    // Filter by partial email
-
-    mockMvc
-            .perform(
-                    get("/v1/users")
-                            .queryParam("email", "alan.turing")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenAdmin))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.totalElements", Matchers.is(1)))
-            .andExpect(jsonPath("$.content[0].email", is(testUser1.getEmail()), String.class));
-
-    // Filter by common substring
-
-    mockMvc
-            .perform(
-                    get("/v1/users")
-                            .queryParam("email", "tech.de")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenAdmin))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.totalElements", Matchers.is(2)))
-            .andExpect(jsonPath("$.content[0].email", is(testUser1.getEmail()), String.class))
-            .andExpect(jsonPath("$.content[1].email", is(testUser2.getEmail()), String.class));
+    @Test
+    @DisplayName("Using common substring should return all user matching the substring")
+    void testCommonSubstringEmailFilter() throws Exception {
+      mockMvc
+          .perform(
+              get("/v1/users")
+                  .queryParam("email", "tech.de")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenAdmin))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.totalElements", Matchers.is(2)))
+          .andExpect(jsonPath("$.content[0].email", is(testUser1.getEmail()), String.class))
+          .andExpect(jsonPath("$.content[1].email", is(testUser2.getEmail()), String.class));
+    }
   }
 
   @Test


### PR DESCRIPTION
Users can be filtered by using only a substring of an email.

* Defined new Specification PartialEmailSpecBase
* Wrote integration test to check filtering by full and partial emails