### PR TITLE
refactor: renamed UserDto in core project to AbstractBaseUserDto, renamed AppUserDto in subprojects to UserDto

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,10 +1,20 @@
 # Migration Guide
 
+## Version `______`
+
+- `UserDto` class has been renamed to `AbstractBaseUserDto`. Each call to the `UserDto` class should be changed to call
+  `AbstractBaseUserDto`.
+- `AppUserDto` classes in the subprojects `identity-model`, `sequence-model`, `uuid-model` have been renamed to
+  `UserDto`.
+
 ## Version `2.7.0`
 
-- All implementations of the `AbstractUserController` should be checked to see whether one of the methods `findById`, `updateObject`, `update`, `delete` or, `terminate` have been overwritten. If this is the case, the method signature must be adapted to the use of specifications. 
+- All implementations of the `AbstractUserController` should be checked to see whether one of the methods `findById`,
+  `updateObject`, `update`, `delete` or, `terminate` have been overwritten. If this is the case, the method signature
+  must be adapted to the use of specifications.
 
 Example:
+
 ```java
 /* old implementation */
 @Override
@@ -13,7 +23,7 @@ Example:
 @Operation(summary = "Retrieve a user by her id")
 public UserRepresentation findById(@PathVariable("id") @NotNull Long id) {
     // do something
-      super.findById(id);
+    super.findById(id);
 }
 
 /* new implementation */
@@ -32,18 +42,22 @@ public UserRepresentation findById(@PathVariable("id") @NotNull Long id,
 
 ### UserService
 
-The used super-constructor in the implementation of the `AbstractUserService` in your application has a new added parameter `AdminRightRoleCache adminRightRoleCache`. You have to change it from
+The used super-constructor in the implementation of the `AbstractUserService` in your application has a new added
+parameter `AdminRightRoleCache adminRightRoleCache`. You have to change it from
+
 ```java
 protected UserService(
-    @NotNull UserRepository userRepository,
-    @NotNull PasswordEncoder passwordEncoder,
-    @NotNull UserMailService userMailService,
-    @NotNull RoleService roleService,
-    @NotNull JwtTokenService jwtTokenService) {
-  super(userRepository, passwordEncoder, userMailService, roleService, jwtTokenService);
+        @NotNull UserRepository userRepository,
+        @NotNull PasswordEncoder passwordEncoder,
+        @NotNull UserMailService userMailService,
+        @NotNull RoleService roleService,
+        @NotNull JwtTokenService jwtTokenService) {
+    super(userRepository, passwordEncoder, userMailService, roleService, jwtTokenService);
 }
 ```
-  to
+
+to
+
 ```java
     protected UserService(
         @NotNull UserRepository userRepository,
@@ -52,29 +66,33 @@ protected UserService(
         @NotNull RoleService roleService,
         @NotNull AdminRightRoleCache adminRightRoleCache,
         @NotNull JwtTokenService jwtTokenService) {
-  super(
-          userRepository,
-          passwordEncoder,
-          userMailService,
-          roleService,
-          adminRightRoleCache,
-          jwtTokenService);
+    super(
+            userRepository,
+            passwordEncoder,
+            userMailService,
+            roleService,
+            adminRightRoleCache,
+            jwtTokenService);
 }
 ```
 
 ### RoleInitializer
 
-If you have your own implementation of `DefaultRoleInitializer` in your application you need to change the super-constructor call from
+If you have your own implementation of `DefaultRoleInitializer` in your application you need to change the
+super-constructor call from
+
 ```java
 public RoleInitializer(
-      InitProperties initProperties,
-      RoleRepository roleRepository,
-      RoleService roleService,
-      RightService rightService) {
-super(initProperties, roleRepository, roleService, rightService);
+        InitProperties initProperties,
+        RoleRepository roleRepository,
+        RoleService roleService,
+        RightService rightService) {
+    super(initProperties, roleRepository, roleService, rightService);
 }
 ```
-  to
+
+to
+
 ```java
 public RoleInitializer(
         InitProperties initProperties,
@@ -82,13 +100,16 @@ public RoleInitializer(
         RoleService roleService,
         RightService rightService,
         AdminRightRoleCache adminRightRoleCache) {
-  super(initProperties, roleRepository, roleService, rightService, adminRightRoleCache);
+    super(initProperties, roleRepository, roleService, rightService, adminRightRoleCache);
 }
 ```
 
 ### LDAP-Authentication
 
-A new environment variable`APP_AUTH_LDAP_GROUP_SEARCH_SUBTREE` respectively `app.auth.ldap.group-search-subtree` has been introduced. If you want to enable the group subtree search, you have to set this variable to `true`. You may alter your `application.yaml` (or `application-ldap.yaml`) as follows:
+A new environment variable`APP_AUTH_LDAP_GROUP_SEARCH_SUBTREE` respectively `app.auth.ldap.group-search-subtree` has
+been introduced. If you want to enable the group subtree search, you have to set this variable to `true`. You may alter
+your `application.yaml` (or `application-ldap.yaml`) as follows:
+
 ```yaml
 app:
   auth:
@@ -116,32 +137,40 @@ app:
 ## Version `2.5.13`
 
 - If your Application has its own `RightInitializer` extending `DefaultRightInitializer` you have to change the
-  constructor from 
+  constructor from
+
 ```java
 public MyRightInitializer(RightService rightService, RoleService roleService) {
-  super(rightService, roleRepository);
+    super(rightService, roleRepository);
 }
 ``` 
-  to 
+
+to
+
 ```java
 public RightInitializer(RightService rightService, RoleRepository roleRepository) {
-  super(rightService, roleRepository);
+    super(rightService, roleRepository);
 }
 ```
+
 ## Version `2.5.4`
 
-If `@Validated` is used, parameter annotations such as `@Email` or `@NotNull` are evaluated and violations result in a `HandlerMethodValidationException`. Since Spring Boot 3.2.2, only the error message `"Validation failure"` is output by default. Essencium therefore implements its own handler that outputs the embedded violations as an error message. Assuming that the parameter `eMail` is incorrect and the mandatory parameter `lastName` is not transmitted at all, the resulting error message is as follows:
+If `@Validated` is used, parameter annotations such as `@Email` or `@NotNull` are evaluated and violations result in a
+`HandlerMethodValidationException`. Since Spring Boot 3.2.2, only the error message `"Validation failure"` is output by
+default. Essencium therefore implements its own handler that outputs the embedded violations as an error message.
+Assuming that the parameter `eMail` is incorrect and the mandatory parameter `lastName` is not transmitted at all, the
+resulting error message is as follows:
 
 ```json
 {
-    "status": 400,
-    "error": "400 BAD_REQUEST \"Validation failure\"",
-    "message": [
-        "email must be a correctly formatted email address",
-        "lastName must not be empty"
-    ],
-    "timestamp": "2024-01-24T09:47:14.443917986",
-    "path": "/v1/users"
+  "status": 400,
+  "error": "400 BAD_REQUEST \"Validation failure\"",
+  "message": [
+    "email must be a correctly formatted email address",
+    "lastName must not be empty"
+  ],
+  "timestamp": "2024-01-24T09:47:14.443917986",
+  "path": "/v1/users"
 }
 ```
 
@@ -151,34 +180,42 @@ The messages are always composed according to the scheme "<parameter name> <mess
 
 ### Access Management
 
-The annotation `@RestrictAccessToOwnedEntities` can be used to restrict access to entities. This makes it possible to restrict access to entities based on the ownership of the entity. You may use it in combination with the `@OwnershipSpec` annotation to specify the ownership of the entity. It can be used on controller class level, controller method level or on the entity class level. If used on the entity class level, the controller has to be annotated with `@ExposesEntity` to tell the application which Class has to be scanned for OwnershipSpecs. In previous versions, the annotation `@ExposesResourceFor` was used for this purpose. Since this annotation was derived from Spring HATEOAS, it is no longer possible to use it for this purpose. Use **`@ExposesEntity`** in your Application instead.
+The annotation `@RestrictAccessToOwnedEntities` can be used to restrict access to entities. This makes it possible to
+restrict access to entities based on the ownership of the entity. You may use it in combination with the
+`@OwnershipSpec` annotation to specify the ownership of the entity. It can be used on controller class level, controller
+method level or on the entity class level. If used on the entity class level, the controller has to be annotated with
+`@ExposesEntity` to tell the application which Class has to be scanned for OwnershipSpecs. In previous versions, the
+annotation `@ExposesResourceFor` was used for this purpose. Since this annotation was derived from Spring HATEOAS, it is
+no longer possible to use it for this purpose. Use **`@ExposesEntity`** in your Application instead.
 
 ## Version `2.5.0`
 
 ### Database connectors
 
-From this version onwards, database dependencies must be defined and integrated at application level. Developers must therefore define one (or more) of the following dependencies in the `pom.xml`:
+From this version onwards, database dependencies must be defined and integrated at application level. Developers must
+therefore define one (or more) of the following dependencies in the `pom.xml`:
 
 ```xml
+
 <dependencies>
     <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
         <version>${postgresql.version}</version>
     </dependency>
-    
+
     <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
         <version>${h2.version}</version>
     </dependency>
-    
+
     <dependency>
         <groupId>org.mariadb.jdbc</groupId>
         <artifactId>mariadb-java-client</artifactId>
         <version>${mariadb.version}</version>
     </dependency>
-  
+
     <dependency>
         <groupId>com.microsoft.sqlserver</groupId>
         <artifactId>mssql-jdbc</artifactId>
@@ -186,13 +223,15 @@ From this version onwards, database dependencies must be defined and integrated 
     </dependency>
 </dependencies>
 ```
+
 _List is not exhaustive._
 
 ### Users, Roles and Rights
 
 Right: Defines a singular attribute that can be checked, for example, for access control in controllers (`@Secured()`).
 Role: Defines a set of rights that can be assigned to users.
-User: Defines a user with a set of roles. The rights of the user result from the sum of the rights of the assigned roles.
+User: Defines a user with a set of roles. The rights of the user result from the sum of the rights of the assigned
+roles.
 
 Roles and Users can now be created via environment variables:
 
@@ -202,7 +241,7 @@ essencium:
     roles:
       - name: ADMIN
         description: Administrator
-        rights: []
+        rights: [ ]
         protected: true
       - name: USER
         description: User
@@ -226,9 +265,11 @@ essencium:
           - USER
 ```
 
-If no roles or users are defined, the default role `ADMIN` having all BasicApplicationRights assigned and no users are created.
+If no roles or users are defined, the default role `ADMIN` having all BasicApplicationRights assigned and no users are
+created.
 
-**Please note that an existing database must be migrated according to the old schema (one role per user)!** For postgresql, the following migration script can be used:
+**Please note that an existing database must be migrated according to the old schema (one role per user)!** For
+postgresql, the following migration script can be used:
 
 ```sql
 ALTER TABLE IF EXISTS "FW_ROLE"
@@ -238,29 +279,58 @@ ALTER TABLE IF EXISTS "FW_ROLE"
 
 CREATE TABLE IF NOT EXISTS "FW_USER_ROLES"
 (
-    "user_id" bigint NOT NULL,
-    "roles_name" character varying(255)  NOT NULL,
-    CONSTRAINT "FW_USER_ROLES_pkey" PRIMARY KEY (user_id, roles_name),
-    CONSTRAINT "FK5x6ca7enc8g15hxhty2s9iikp" FOREIGN KEY (roles_name)
-        REFERENCES "FW_ROLE" (name) MATCH SIMPLE
-        ON UPDATE NO ACTION
-        ON DELETE NO ACTION,
-    CONSTRAINT "FKh0k8otxier8qii1l14gvc87wi" FOREIGN KEY (user_id)
-        REFERENCES "FW_USER" (id) MATCH SIMPLE
-        ON UPDATE NO ACTION
-        ON DELETE NO ACTION
-);
+    "user_id"
+    bigint
+    NOT
+    NULL,
+    "roles_name"
+    character
+    varying
+(
+    255
+) NOT NULL,
+    CONSTRAINT "FW_USER_ROLES_pkey" PRIMARY KEY
+(
+    user_id,
+    roles_name
+),
+    CONSTRAINT "FK5x6ca7enc8g15hxhty2s9iikp" FOREIGN KEY
+(
+    roles_name
+)
+    REFERENCES "FW_ROLE"
+(
+    name
+) MATCH SIMPLE
+    ON UPDATE NO ACTION
+    ON DELETE NO ACTION,
+    CONSTRAINT "FKh0k8otxier8qii1l14gvc87wi" FOREIGN KEY
+(
+    user_id
+)
+    REFERENCES "FW_USER"
+(
+    id
+) MATCH SIMPLE
+    ON UPDATE NO ACTION
+    ON DELETE NO ACTION
+    );
 
-INSERT INTO "FW_USER_ROLES" ("user_id", "roles_name") SELECT "id", "role_name" FROM "FW_USER";
+INSERT INTO "FW_USER_ROLES" ("user_id", "roles_name")
+SELECT "id", "role_name"
+FROM "FW_USER";
 
 ALTER TABLE "FW_USER" DROP COLUMN "role_name";
 ```
 
-This SQL script requires that the database schema corresponds at least to the schema of Essencium version 2.3.0 (Flyway Migration 2.3.2). For the migration of previous Essencium versions, see [essencium-backend-development/src/main/resources/migrations](essencium-backend-development/src/main/resources/migrations).
+This SQL script requires that the database schema corresponds at least to the schema of Essencium version 2.3.0 (Flyway
+Migration 2.3.2). For the migration of previous Essencium versions,
+see [essencium-backend-development/src/main/resources/migrations](essencium-backend-development/src/main/resources/migrations).
 
 ### Environment
 
-With regard to the environment variables, the previous root element 'essencium-backend' has been renamed to 'essencium'. For example, `essencium-backend.jpa.table-prefix: "FW_"` will now be `essencium.jpa.table-prefix: "FW_"`.
+With regard to the environment variables, the previous root element 'essencium-backend' has been renamed to 'essencium'.
+For example, `essencium-backend.jpa.table-prefix: "FW_"` will now be `essencium.jpa.table-prefix: "FW_"`.
 As a result, the following previous variables are completely omitted:
 
 - `essencium-backend.overrides.*`
@@ -579,114 +649,241 @@ CREATE SEQUENCE IF NOT EXISTS hibernate_sequence
 -- create potentially non-existing tables
 CREATE TABLE IF NOT EXISTS "FW_USER"
 (
-    id                    bigint                 NOT NULL,
-    created_at            timestamp(6) without time zone,
-    created_by            character varying(255),
-    updated_at            timestamp(6) without time zone,
-    updated_by            character varying(255),
-    email                 character varying(150),
-    enabled               boolean                NOT NULL,
-    failed_login_attempts integer                NOT NULL DEFAULT 0,
-    first_name            character varying(255),
-    last_name             character varying(255),
-    locale                character varying(255) NOT NULL,
-    login_disabled        boolean                NOT NULL,
-    mobile                character varying(255),
-    nonce                 character varying(255),
-    password              character varying(255),
-    password_reset_token  character varying(255),
-    phone                 character varying(255),
-    source                character varying(255),
-    role_id               bigint                 NOT NULL,
-    CONSTRAINT "FW_USER_pkey" PRIMARY KEY (id),
-    CONSTRAINT uk_o5gwjnjfosht4tf5lq48rxfoj UNIQUE (email)
-);
+    id
+    bigint
+    NOT
+    NULL,
+    created_at
+    timestamp
+(
+    6
+) without time zone,
+    created_by character varying
+(
+    255
+),
+    updated_at timestamp
+(
+    6
+)
+  without time zone,
+    updated_by character varying
+(
+    255
+),
+    email character varying
+(
+    150
+),
+    enabled boolean NOT NULL,
+    failed_login_attempts integer NOT NULL DEFAULT 0,
+    first_name character varying
+(
+    255
+),
+    last_name character varying
+(
+    255
+),
+    locale character varying
+(
+    255
+) NOT NULL,
+    login_disabled boolean NOT NULL,
+    mobile character varying
+(
+    255
+),
+    nonce character varying
+(
+    255
+),
+    password character varying
+(
+    255
+),
+    password_reset_token character varying
+(
+    255
+),
+    phone character varying
+(
+    255
+),
+    source character varying
+(
+    255
+),
+    role_id bigint NOT NULL,
+    CONSTRAINT "FW_USER_pkey" PRIMARY KEY
+(
+    id
+),
+    CONSTRAINT uk_o5gwjnjfosht4tf5lq48rxfoj UNIQUE
+(
+    email
+)
+    );
 CREATE TABLE IF NOT EXISTS "FW_RIGHT"
 (
-    id          bigint                 NOT NULL,
-    created_at  timestamp(6) without time zone,
-    created_by  character varying(255),
-    updated_at  timestamp(6) without time zone,
-    updated_by  character varying(255),
-    description character varying(512),
-    name        character varying(255) NOT NULL,
-    CONSTRAINT "FW_RIGHT_pkey" PRIMARY KEY (id),
-    CONSTRAINT uk_jep1itavphekmnphj0vp38s9u UNIQUE (name)
-);
+    id
+    bigint
+    NOT
+    NULL,
+    created_at
+    timestamp
+(
+    6
+) without time zone,
+    created_by character varying
+(
+    255
+),
+    updated_at timestamp
+(
+    6
+)
+  without time zone,
+    updated_by character varying
+(
+    255
+),
+    description character varying
+(
+    512
+),
+    name character varying
+(
+    255
+) NOT NULL,
+    CONSTRAINT "FW_RIGHT_pkey" PRIMARY KEY
+(
+    id
+),
+    CONSTRAINT uk_jep1itavphekmnphj0vp38s9u UNIQUE
+(
+    name
+)
+    );
 CREATE TABLE IF NOT EXISTS "FW_ROLE"
 (
-    id           bigint                 NOT NULL,
-    created_at   timestamp(6) without time zone,
-    created_by   character varying(255),
-    updated_at   timestamp(6) without time zone,
-    updated_by   character varying(255),
-    description  character varying(255),
-    is_protected boolean                NOT NULL,
-    name         character varying(255) NOT NULL,
-    CONSTRAINT "FW_ROLE_pkey" PRIMARY KEY (id)
-);
+    id
+    bigint
+    NOT
+    NULL,
+    created_at
+    timestamp
+(
+    6
+) without time zone,
+    created_by character varying
+(
+    255
+),
+    updated_at timestamp
+(
+    6
+)
+  without time zone,
+    updated_by character varying
+(
+    255
+),
+    description character varying
+(
+    255
+),
+    is_protected boolean NOT NULL,
+    name character varying
+(
+    255
+) NOT NULL,
+    CONSTRAINT "FW_ROLE_pkey" PRIMARY KEY
+(
+    id
+)
+    );
 CREATE TABLE IF NOT EXISTS "FW_ROLE_RIGHTS"
 (
-    role_id   bigint NOT NULL,
-    rights_id bigint NOT NULL,
-    CONSTRAINT "FW_ROLE_RIGHTS_pkey" PRIMARY KEY (role_id, rights_id)
-);
+    role_id
+    bigint
+    NOT
+    NULL,
+    rights_id
+    bigint
+    NOT
+    NULL,
+    CONSTRAINT
+    "FW_ROLE_RIGHTS_pkey"
+    PRIMARY
+    KEY
+(
+    role_id,
+    rights_id
+)
+    );
 
 -- USER -> ROLE
 ALTER TABLE IF EXISTS "FW_USER"
-    ADD COLUMN "role_name" VARCHAR(255);
+    ADD COLUMN "role_name" VARCHAR (255);
 
 UPDATE "FW_USER"
-SET role_name = role.name
-FROM "FW_ROLE" role
+SET role_name = role.name FROM "FW_ROLE" role
 WHERE role.id = "FW_USER".role_id;
 
 ALTER TABLE IF EXISTS "FW_USER"
-    DROP CONSTRAINT IF EXISTS "FKnpftnul0ve9guxtoqakx201de";
+DROP
+CONSTRAINT IF EXISTS "FKnpftnul0ve9guxtoqakx201de";
 
 ALTER TABLE IF EXISTS "FW_USER"
-    DROP COLUMN IF EXISTS role_id;
+DROP
+COLUMN IF EXISTS role_id;
 
 -- ROLE -> RIGHT
 ALTER TABLE IF EXISTS "FW_ROLE_RIGHTS"
-    ADD COLUMN "role_name" VARCHAR(255);
+    ADD COLUMN "role_name" VARCHAR (255);
 
 UPDATE "FW_ROLE_RIGHTS"
-SET role_name = role.name
-FROM "FW_ROLE" role
+SET role_name = role.name FROM "FW_ROLE" role
 WHERE role.id = "FW_ROLE_RIGHTS".role_id;
 
 -- RIGHT --> ROLE
 ALTER TABLE IF EXISTS "FW_ROLE_RIGHTS"
-    ADD COLUMN "rights_authority" VARCHAR(255);
+    ADD COLUMN "rights_authority" VARCHAR (255);
 ALTER TABLE IF EXISTS "FW_RIGHT"
     RENAME name TO authority;
 
 UPDATE "FW_ROLE_RIGHTS"
-SET rights_authority = appright.authority
-FROM "FW_RIGHT" appright
+SET rights_authority = appright.authority FROM "FW_RIGHT" appright
 WHERE appright.id = "FW_ROLE_RIGHTS".rights_id;
 
 -- Remove old Constraints
 ALTER TABLE IF EXISTS "FW_ROLE_RIGHTS"
-    DROP CONSTRAINT IF EXISTS "FK4akiafdy6sibodflxw662bf0x";
+DROP
+CONSTRAINT IF EXISTS "FK4akiafdy6sibodflxw662bf0x";
 ALTER TABLE IF EXISTS "FW_ROLE_RIGHTS"
-    DROP CONSTRAINT IF EXISTS "FKc28mpb53220tvxffq0buv1sc6";
+DROP
+CONSTRAINT IF EXISTS "FKc28mpb53220tvxffq0buv1sc6";
 
 -- Remove old Primary Keys
 ALTER TABLE IF EXISTS "FW_ROLE_RIGHTS"
-    DROP CONSTRAINT IF EXISTS "FW_ROLE_RIGHTS_pkey";
+DROP
+CONSTRAINT IF EXISTS "FW_ROLE_RIGHTS_pkey";
 
 ALTER TABLE IF EXISTS "FW_ROLE"
-    DROP COLUMN IF EXISTS id;
+DROP
+COLUMN IF EXISTS id;
 ALTER TABLE IF EXISTS "FW_RIGHT"
-    DROP COLUMN IF EXISTS id;
+DROP
+COLUMN IF EXISTS id;
 
 -- Remove old Columns
 ALTER TABLE IF EXISTS "FW_ROLE_RIGHTS"
-    DROP COLUMN "role_id";
+DROP
+COLUMN "role_id";
 ALTER TABLE IF EXISTS "FW_ROLE_RIGHTS"
-    DROP COLUMN "rights_id";
+DROP
+COLUMN "rights_id";
 
 -- Add new Primary Keys
 ALTER TABLE IF EXISTS "FW_ROLE"
@@ -699,37 +896,54 @@ ALTER TABLE IF EXISTS "FW_ROLE_RIGHTS"
 -- Add new Constraints
 ALTER TABLE IF EXISTS "FW_USER"
     ADD CONSTRAINT "FK8xvm8eci4kcyn46nr2xd4axx9" FOREIGN KEY ("role_name") REFERENCES "FW_ROLE" ("name") MATCH SIMPLE
-        ON UPDATE NO ACTION
-        ON DELETE NO ACTION;
+    ON
+UPDATE NO ACTION
+ON
+DELETE
+NO ACTION;
 ALTER TABLE IF EXISTS "FW_ROLE_RIGHTS"
     ADD CONSTRAINT "FKhqod6jll49rbgohaml3pi5ofi" FOREIGN KEY ("rights_authority")
-        REFERENCES "FW_RIGHT" ("authority") MATCH SIMPLE
-        ON UPDATE NO ACTION
-        ON DELETE NO ACTION;
+    REFERENCES "FW_RIGHT" ("authority") MATCH SIMPLE
+    ON
+UPDATE NO ACTION
+ON
+DELETE
+NO ACTION;
 ALTER TABLE IF EXISTS "FW_ROLE_RIGHTS"
     ADD CONSTRAINT "FKillb2aaughbvyxj9j8sa9835g" FOREIGN KEY ("role_name")
-        REFERENCES "FW_ROLE" ("name") MATCH SIMPLE
-        ON UPDATE NO ACTION
-        ON DELETE NO ACTION;
+    REFERENCES "FW_ROLE" ("name") MATCH SIMPLE
+    ON
+UPDATE NO ACTION
+ON
+DELETE
+NO ACTION;
 
 -- Delete obsolete Columns
 ALTER TABLE IF EXISTS "FW_RIGHT"
-    DROP COLUMN IF EXISTS created_at;
+DROP
+COLUMN IF EXISTS created_at;
 ALTER TABLE IF EXISTS "FW_RIGHT"
-    DROP COLUMN IF EXISTS created_by;
+DROP
+COLUMN IF EXISTS created_by;
 ALTER TABLE IF EXISTS "FW_RIGHT"
-    DROP COLUMN IF EXISTS updated_at;
+DROP
+COLUMN IF EXISTS updated_at;
 ALTER TABLE IF EXISTS "FW_RIGHT"
-    DROP COLUMN IF EXISTS updated_by;
+DROP
+COLUMN IF EXISTS updated_by;
 
 ALTER TABLE IF EXISTS "FW_ROLE"
-    DROP COLUMN IF EXISTS created_at;
+DROP
+COLUMN IF EXISTS created_at;
 ALTER TABLE IF EXISTS "FW_ROLE"
-    DROP COLUMN IF EXISTS created_by;
+DROP
+COLUMN IF EXISTS created_by;
 ALTER TABLE IF EXISTS "FW_ROLE"
-    DROP COLUMN IF EXISTS updated_at;
+DROP
+COLUMN IF EXISTS updated_at;
 ALTER TABLE IF EXISTS "FW_ROLE"
-    DROP COLUMN IF EXISTS updated_by;
+DROP
+COLUMN IF EXISTS updated_by;
 ```
 
 ## Migrate to `2.2.0`
@@ -816,7 +1030,8 @@ public class MyUserRepresentationAssembler
 - Replace `org.jetbrains.annotations.Nullable` with `jakarta.annotation.Nullable` in all files
 - If you have overridden or extended the `DefaultRoleInitializer` you have to change the
   constructor from `public MyRoleInitializer(RightService rightService, RoleService roleService) `
-  to `public MyRoleInitializer(RightService rightService, RoleService roleService, DefaultRoleProperties defaultRoleProperties)`
+  to
+  `public MyRoleInitializer(RightService rightService, RoleService roleService, DefaultRoleProperties defaultRoleProperties)`
 - If you have accessed `USER_ROLE_NAME` or `USER_ROLE_DESCRIPTION` provided by `DefaultRoleInitializer` you have to
   change it to `defaultRoleProperties.getName()` and `defaultRoleProperties.getDescription()` respectively.
 
@@ -911,7 +1126,8 @@ Breaking Changes concerning openApi documentation
 - The Dependency `com.cosium.code.maven-git-code-format` has to be replaced
   by `com.cosium.code.git-code-format-maven-plugin` using version `4.2` (or higher)
     -
-  Use `mvn org.codehaus.mojo:build-helper-maven-plugin:add-test-source@add-integration-test-sources git-code-format:format-code`
+  Use
+  `mvn org.codehaus.mojo:build-helper-maven-plugin:add-test-source@add-integration-test-sources git-code-format:format-code`
   to format your code completely (including Integration Tests, see [README](./README.md))
 
 :warning: Individually, the version statuses of each dependency used must be checked and updated.

--- a/essencium-backend-identity-model/src/main/java/de/frachtwerk/essencium/backend/controller/UserController.java
+++ b/essencium-backend-identity-model/src/main/java/de/frachtwerk/essencium/backend/controller/UserController.java
@@ -20,7 +20,7 @@
 package de.frachtwerk.essencium.backend.controller;
 
 import de.frachtwerk.essencium.backend.model.User;
-import de.frachtwerk.essencium.backend.model.dto.AppUserDto;
+import de.frachtwerk.essencium.backend.model.dto.UserDto;
 import de.frachtwerk.essencium.backend.model.representation.UserRepresentation;
 import de.frachtwerk.essencium.backend.model.representation.assembler.UserAssembler;
 import de.frachtwerk.essencium.backend.repository.specification.BaseUserSpec;
@@ -32,7 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/users")
 public class UserController
     extends AbstractUserController<
-        User, UserRepresentation, AppUserDto, BaseUserSpec<User, Long>, Long> {
+        User, UserRepresentation, UserDto, BaseUserSpec<User, Long>, Long> {
 
   protected UserController(UserService userService, UserAssembler assembler) {
     super(userService, assembler);

--- a/essencium-backend-identity-model/src/main/java/de/frachtwerk/essencium/backend/model/dto/UserDto.java
+++ b/essencium-backend-identity-model/src/main/java/de/frachtwerk/essencium/backend/model/dto/UserDto.java
@@ -19,7 +19,6 @@
 
 package de.frachtwerk.essencium.backend.model.dto;
 
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -27,4 +26,4 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 @Data
 @AllArgsConstructor
-public class AppUserDto extends UserDto<UUID> {}
+public class UserDto extends AbstractBaseUserDto<Long> {}

--- a/essencium-backend-identity-model/src/main/java/de/frachtwerk/essencium/backend/service/UserService.java
+++ b/essencium-backend-identity-model/src/main/java/de/frachtwerk/essencium/backend/service/UserService.java
@@ -21,7 +21,7 @@ package de.frachtwerk.essencium.backend.service;
 
 import de.frachtwerk.essencium.backend.model.Role;
 import de.frachtwerk.essencium.backend.model.User;
-import de.frachtwerk.essencium.backend.model.dto.AppUserDto;
+import de.frachtwerk.essencium.backend.model.dto.UserDto;
 import de.frachtwerk.essencium.backend.repository.UserRepository;
 import jakarta.validation.constraints.NotNull;
 import java.util.Set;
@@ -30,7 +30,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
-public class UserService extends AbstractUserService<User, Long, AppUserDto> {
+public class UserService extends AbstractUserService<User, Long, UserDto> {
 
   protected UserService(
       @NotNull UserRepository userRepository,
@@ -49,7 +49,7 @@ public class UserService extends AbstractUserService<User, Long, AppUserDto> {
   }
 
   @Override
-  protected @NotNull <E extends AppUserDto> User convertDtoToEntity(@NotNull E entity) {
+  protected @NotNull <E extends UserDto> User convertDtoToEntity(@NotNull E entity) {
     Set<Role> roles =
         entity.getRoles().stream().map(roleService::getByName).collect(Collectors.toSet());
     return User.builder()
@@ -68,7 +68,7 @@ public class UserService extends AbstractUserService<User, Long, AppUserDto> {
   }
 
   @Override
-  public AppUserDto getNewUser() {
-    return new AppUserDto();
+  public UserDto getNewUser() {
+    return new UserDto();
   }
 }

--- a/essencium-backend-sequence-model/src/main/java/de/frachtwerk/essencium/backend/controller/UserController.java
+++ b/essencium-backend-sequence-model/src/main/java/de/frachtwerk/essencium/backend/controller/UserController.java
@@ -20,7 +20,7 @@
 package de.frachtwerk.essencium.backend.controller;
 
 import de.frachtwerk.essencium.backend.model.User;
-import de.frachtwerk.essencium.backend.model.dto.AppUserDto;
+import de.frachtwerk.essencium.backend.model.dto.UserDto;
 import de.frachtwerk.essencium.backend.model.representation.UserRepresentation;
 import de.frachtwerk.essencium.backend.model.representation.assembler.UserAssembler;
 import de.frachtwerk.essencium.backend.repository.specification.BaseUserSpec;
@@ -32,7 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/users")
 public class UserController
     extends AbstractUserController<
-        User, UserRepresentation, AppUserDto, BaseUserSpec<User, Long>, Long> {
+        User, UserRepresentation, UserDto, BaseUserSpec<User, Long>, Long> {
 
   protected UserController(UserService userService, UserAssembler assembler) {
     super(userService, assembler);

--- a/essencium-backend-sequence-model/src/main/java/de/frachtwerk/essencium/backend/model/dto/UserDto.java
+++ b/essencium-backend-sequence-model/src/main/java/de/frachtwerk/essencium/backend/model/dto/UserDto.java
@@ -26,4 +26,4 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 @Data
 @AllArgsConstructor
-public class AppUserDto extends UserDto<Long> {}
+public class UserDto extends AbstractBaseUserDto<Long> {}

--- a/essencium-backend-sequence-model/src/main/java/de/frachtwerk/essencium/backend/service/UserService.java
+++ b/essencium-backend-sequence-model/src/main/java/de/frachtwerk/essencium/backend/service/UserService.java
@@ -21,7 +21,7 @@ package de.frachtwerk.essencium.backend.service;
 
 import de.frachtwerk.essencium.backend.model.Role;
 import de.frachtwerk.essencium.backend.model.User;
-import de.frachtwerk.essencium.backend.model.dto.AppUserDto;
+import de.frachtwerk.essencium.backend.model.dto.UserDto;
 import de.frachtwerk.essencium.backend.repository.UserRepository;
 import jakarta.validation.constraints.NotNull;
 import java.util.Set;
@@ -30,7 +30,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
-public class UserService extends AbstractUserService<User, Long, AppUserDto> {
+public class UserService extends AbstractUserService<User, Long, UserDto> {
 
   protected UserService(
       @NotNull UserRepository userRepository,
@@ -49,7 +49,7 @@ public class UserService extends AbstractUserService<User, Long, AppUserDto> {
   }
 
   @Override
-  protected @NotNull <E extends AppUserDto> User convertDtoToEntity(@NotNull E entity) {
+  protected @NotNull <E extends UserDto> User convertDtoToEntity(@NotNull E entity) {
     Set<Role> roles =
         entity.getRoles().stream().map(roleService::getByName).collect(Collectors.toSet());
     return User.builder()
@@ -68,7 +68,7 @@ public class UserService extends AbstractUserService<User, Long, AppUserDto> {
   }
 
   @Override
-  public AppUserDto getNewUser() {
-    return new AppUserDto();
+  public UserDto getNewUser() {
+    return new UserDto();
   }
 }

--- a/essencium-backend-uuid-model/src/main/java/de/frachtwerk/essencium/backend/controller/UserController.java
+++ b/essencium-backend-uuid-model/src/main/java/de/frachtwerk/essencium/backend/controller/UserController.java
@@ -20,7 +20,7 @@
 package de.frachtwerk.essencium.backend.controller;
 
 import de.frachtwerk.essencium.backend.model.User;
-import de.frachtwerk.essencium.backend.model.dto.AppUserDto;
+import de.frachtwerk.essencium.backend.model.dto.UserDto;
 import de.frachtwerk.essencium.backend.model.representation.UserRepresentation;
 import de.frachtwerk.essencium.backend.model.representation.assembler.UserAssembler;
 import de.frachtwerk.essencium.backend.repository.specification.BaseUserSpec;
@@ -33,7 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/users")
 public class UserController
     extends AbstractUserController<
-        User, UserRepresentation, AppUserDto, BaseUserSpec<User, UUID>, UUID> {
+        User, UserRepresentation, UserDto, BaseUserSpec<User, UUID>, UUID> {
 
   protected UserController(UserService userService, UserAssembler assembler) {
     super(userService, assembler);

--- a/essencium-backend-uuid-model/src/main/java/de/frachtwerk/essencium/backend/model/dto/UserDto.java
+++ b/essencium-backend-uuid-model/src/main/java/de/frachtwerk/essencium/backend/model/dto/UserDto.java
@@ -19,6 +19,7 @@
 
 package de.frachtwerk.essencium.backend.model.dto;
 
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -26,4 +27,4 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 @Data
 @AllArgsConstructor
-public class AppUserDto extends UserDto<Long> {}
+public class UserDto extends AbstractBaseUserDto<UUID> {}

--- a/essencium-backend-uuid-model/src/main/java/de/frachtwerk/essencium/backend/service/UserService.java
+++ b/essencium-backend-uuid-model/src/main/java/de/frachtwerk/essencium/backend/service/UserService.java
@@ -21,7 +21,7 @@ package de.frachtwerk.essencium.backend.service;
 
 import de.frachtwerk.essencium.backend.model.Role;
 import de.frachtwerk.essencium.backend.model.User;
-import de.frachtwerk.essencium.backend.model.dto.AppUserDto;
+import de.frachtwerk.essencium.backend.model.dto.UserDto;
 import de.frachtwerk.essencium.backend.repository.UserRepository;
 import jakarta.validation.constraints.NotNull;
 import java.util.Set;
@@ -31,7 +31,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
-public class UserService extends AbstractUserService<User, UUID, AppUserDto> {
+public class UserService extends AbstractUserService<User, UUID, UserDto> {
 
   protected UserService(
       @NotNull UserRepository userRepository,
@@ -50,7 +50,7 @@ public class UserService extends AbstractUserService<User, UUID, AppUserDto> {
   }
 
   @Override
-  protected @NotNull <E extends AppUserDto> User convertDtoToEntity(@NotNull E entity) {
+  protected @NotNull <E extends UserDto> User convertDtoToEntity(@NotNull E entity) {
     Set<Role> roles =
         entity.getRoles().stream().map(roleService::getByName).collect(Collectors.toSet());
     return User.builder()
@@ -69,7 +69,7 @@ public class UserService extends AbstractUserService<User, UUID, AppUserDto> {
   }
 
   @Override
-  public AppUserDto getNewUser() {
-    return new AppUserDto();
+  public UserDto getNewUser() {
+    return new UserDto();
   }
 }

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/configuration/SpecificationArgumentsResolverConfig.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/configuration/SpecificationArgumentsResolverConfig.java
@@ -21,7 +21,7 @@ package de.frachtwerk.essencium.backend.configuration;
 
 import de.frachtwerk.essencium.backend.controller.access.AccessAwareSpecArgResolver;
 import de.frachtwerk.essencium.backend.model.AbstractBaseUser;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.service.AbstractUserService;
 import java.io.Serializable;
 import java.util.List;
@@ -35,7 +35,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 @RequiredArgsConstructor
 public class SpecificationArgumentsResolverConfig<
-        USER extends AbstractBaseUser<ID>, T extends UserDto<ID>, ID extends Serializable>
+        USER extends AbstractBaseUser<ID>,
+        T extends AbstractBaseUserDto<ID>,
+        ID extends Serializable>
     implements WebMvcConfigurer {
   private final AbstractApplicationContext applicationContext;
   private final AbstractUserService<USER, ID, T> userService;

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/configuration/WebSecurityConfig.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/configuration/WebSecurityConfig.java
@@ -23,7 +23,7 @@ import de.frachtwerk.essencium.backend.configuration.properties.LdapConfigProper
 import de.frachtwerk.essencium.backend.configuration.properties.UserRoleMapping;
 import de.frachtwerk.essencium.backend.configuration.properties.oauth.OAuth2ConfigProperties;
 import de.frachtwerk.essencium.backend.model.AbstractBaseUser;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.security.*;
 import de.frachtwerk.essencium.backend.security.oauth2.OAuth2AuthorizationRequestRepository;
 import de.frachtwerk.essencium.backend.security.oauth2.OAuth2FailureHandler;
@@ -74,9 +74,9 @@ import org.springframework.util.CollectionUtils;
 @RequiredArgsConstructor
 public class WebSecurityConfig<
     USER extends AbstractBaseUser<ID>,
-    T extends UserDto<ID>,
+    T extends AbstractBaseUserDto<ID>,
     ID extends Serializable,
-    USERDTO extends UserDto<ID>> {
+    USERDTO extends AbstractBaseUserDto<ID>> {
 
   private static final Logger LOG = LoggerFactory.getLogger(WebSecurityConfig.class);
 

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/configuration/initialization/DefaultDataInitializationConfiguration.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/configuration/initialization/DefaultDataInitializationConfiguration.java
@@ -20,7 +20,7 @@
 package de.frachtwerk.essencium.backend.configuration.initialization;
 
 import de.frachtwerk.essencium.backend.model.AbstractBaseUser;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import jakarta.annotation.PostConstruct;
 import java.io.Serializable;
 import java.util.List;
@@ -33,7 +33,9 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @RequiredArgsConstructor
 public class DefaultDataInitializationConfiguration<
-        USER extends AbstractBaseUser<ID>, ID extends Serializable, USERDTO extends UserDto<ID>>
+        USER extends AbstractBaseUser<ID>,
+        ID extends Serializable,
+        USERDTO extends AbstractBaseUserDto<ID>>
     implements DataInitializationConfiguration {
 
   private static final Logger LOGGER =

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/configuration/initialization/DefaultUserInitializer.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/configuration/initialization/DefaultUserInitializer.java
@@ -23,7 +23,7 @@ import de.frachtwerk.essencium.backend.configuration.properties.InitProperties;
 import de.frachtwerk.essencium.backend.configuration.properties.UserProperties;
 import de.frachtwerk.essencium.backend.model.AbstractBaseUser;
 import de.frachtwerk.essencium.backend.model.Role;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.service.AbstractUserService;
 import java.io.Serializable;
 import java.util.*;
@@ -36,7 +36,9 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @RequiredArgsConstructor
 public class DefaultUserInitializer<
-        USER extends AbstractBaseUser<ID>, USERDTO extends UserDto<ID>, ID extends Serializable>
+        USER extends AbstractBaseUser<ID>,
+        USERDTO extends AbstractBaseUserDto<ID>,
+        ID extends Serializable>
     implements DataInitializer {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultUserInitializer.class);

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/AbstractUserController.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/AbstractUserController.java
@@ -21,8 +21,8 @@ package de.frachtwerk.essencium.backend.controller;
 
 import de.frachtwerk.essencium.backend.model.AbstractBaseUser;
 import de.frachtwerk.essencium.backend.model.Role;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.model.dto.PasswordUpdateRequest;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
 import de.frachtwerk.essencium.backend.model.exception.DuplicateResourceException;
 import de.frachtwerk.essencium.backend.model.exception.ResourceNotFoundException;
 import de.frachtwerk.essencium.backend.model.representation.BasicRepresentation;
@@ -66,7 +66,7 @@ import org.springframework.web.bind.annotation.*;
 public abstract class AbstractUserController<
     USER extends AbstractBaseUser<ID>,
     REPRESENTATION,
-    USERDTO extends UserDto<ID>,
+    USERDTO extends AbstractBaseUserDto<ID>,
     SPEC extends BaseUserSpec<USER, ID>,
     ID extends Serializable> {
 

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/ResetCredentialsController.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/ResetCredentialsController.java
@@ -20,8 +20,8 @@
 package de.frachtwerk.essencium.backend.controller;
 
 import de.frachtwerk.essencium.backend.model.AbstractBaseUser;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.model.dto.PasswordUpdateRequest;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
 import de.frachtwerk.essencium.backend.service.AbstractUserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -48,7 +48,9 @@ import org.springframework.web.bind.annotation.*;
     description =
         "Set of endpoints used to reset a user's credentials, given a valid reset token as previously received via email")
 public class ResetCredentialsController<
-    USER extends AbstractBaseUser<ID>, ID extends Serializable, USERDTO extends UserDto<ID>> {
+    USER extends AbstractBaseUser<ID>,
+    ID extends Serializable,
+    USERDTO extends AbstractBaseUserDto<ID>> {
 
   private final AbstractUserService<USER, ID, USERDTO> userService;
   private final Random random;

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/access/AccessAwareSpecArgResolver.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/access/AccessAwareSpecArgResolver.java
@@ -20,7 +20,7 @@
 package de.frachtwerk.essencium.backend.controller.access;
 
 import de.frachtwerk.essencium.backend.model.AbstractBaseUser;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.service.AbstractUserService;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
@@ -41,7 +41,9 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 public class AccessAwareSpecArgResolver<
-        USER extends AbstractBaseUser<ID>, ID extends Serializable, USERDTO extends UserDto<ID>>
+        USER extends AbstractBaseUser<ID>,
+        ID extends Serializable,
+        USERDTO extends AbstractBaseUserDto<ID>>
     extends SpecificationArgumentResolver {
   private static final Logger LOG = LoggerFactory.getLogger(AccessAwareSpecArgResolver.class);
 

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/dto/AbstractBaseUserDto.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/dto/AbstractBaseUserDto.java
@@ -41,7 +41,7 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
-public class UserDto<ID extends Serializable> {
+public class AbstractBaseUserDto<ID extends Serializable> {
   public static final Locale DEFAULT_LOCALE = Locale.GERMAN;
 
   @Nullable private ID id;
@@ -66,7 +66,7 @@ public class UserDto<ID extends Serializable> {
 
   @JsonIgnore private String passwordResetToken;
 
-  @NotNull @Builder.Default private Locale locale = UserDto.DEFAULT_LOCALE;
+  @NotNull @Builder.Default private Locale locale = AbstractBaseUserDto.DEFAULT_LOCALE;
 
   @NotNull @Builder.Default private Set<String> roles = new HashSet<>();
 

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/security/JwtAuthenticationProvider.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/security/JwtAuthenticationProvider.java
@@ -20,7 +20,7 @@
 package de.frachtwerk.essencium.backend.security;
 
 import de.frachtwerk.essencium.backend.model.AbstractBaseUser;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.service.AbstractUserService;
 import de.frachtwerk.essencium.backend.service.JwtTokenService;
 import io.jsonwebtoken.Claims;
@@ -37,7 +37,9 @@ import org.springframework.security.web.authentication.www.NonceExpiredException
 
 /** Provider to fetch user details for a previously extracted and validated JWT token */
 public class JwtAuthenticationProvider<
-        USER extends AbstractBaseUser<ID>, ID extends Serializable, USERDTO extends UserDto<ID>>
+        USER extends AbstractBaseUser<ID>,
+        ID extends Serializable,
+        USERDTO extends AbstractBaseUserDto<ID>>
     extends AbstractUserDetailsAuthenticationProvider {
 
   @Autowired private AbstractUserService<USER, ID, USERDTO> userService;

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/security/LdapUserContextMapper.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/security/LdapUserContextMapper.java
@@ -23,7 +23,7 @@ import de.frachtwerk.essencium.backend.configuration.properties.LdapConfigProper
 import de.frachtwerk.essencium.backend.model.AbstractBaseUser;
 import de.frachtwerk.essencium.backend.model.Role;
 import de.frachtwerk.essencium.backend.model.UserInfoEssentials;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.service.AbstractUserService;
 import de.frachtwerk.essencium.backend.service.RoleService;
 import java.io.Serializable;
@@ -45,7 +45,9 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class LdapUserContextMapper<
-        USER extends AbstractBaseUser<ID>, ID extends Serializable, USERDTO extends UserDto<ID>>
+        USER extends AbstractBaseUser<ID>,
+        ID extends Serializable,
+        USERDTO extends AbstractBaseUserDto<ID>>
     implements UserDetailsContextMapper {
 
   private final AbstractUserService<USER, ID, USERDTO> userService;

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/security/oauth2/OAuth2SuccessHandler.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/security/oauth2/OAuth2SuccessHandler.java
@@ -25,7 +25,7 @@ import de.frachtwerk.essencium.backend.model.AbstractBaseUser;
 import de.frachtwerk.essencium.backend.model.Role;
 import de.frachtwerk.essencium.backend.model.SessionTokenType;
 import de.frachtwerk.essencium.backend.model.UserInfoEssentials;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.model.exception.checked.UserEssentialsException;
 import de.frachtwerk.essencium.backend.security.oauth2.util.CookieUtil;
 import de.frachtwerk.essencium.backend.service.AbstractUserService;
@@ -54,7 +54,9 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler<
-        USER extends AbstractBaseUser<ID>, ID extends Serializable, USERDTO extends UserDto<ID>>
+        USER extends AbstractBaseUser<ID>,
+        ID extends Serializable,
+        USERDTO extends AbstractBaseUserDto<ID>>
     implements AuthenticationSuccessHandler {
 
   public static final String OIDC_FIRST_NAME_ATTR = "given_name";

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/AbstractUserService.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/AbstractUserService.java
@@ -25,8 +25,8 @@ import de.frachtwerk.essencium.backend.model.AbstractBaseUser;
 import de.frachtwerk.essencium.backend.model.Role;
 import de.frachtwerk.essencium.backend.model.SessionToken;
 import de.frachtwerk.essencium.backend.model.UserInfoEssentials;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.model.dto.PasswordUpdateRequest;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
 import de.frachtwerk.essencium.backend.model.exception.NotAllowedException;
 import de.frachtwerk.essencium.backend.model.exception.ResourceNotFoundException;
 import de.frachtwerk.essencium.backend.model.exception.checked.CheckedMailException;
@@ -51,7 +51,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.session.SessionAuthenticationException;
 
 public abstract class AbstractUserService<
-        USER extends AbstractBaseUser<ID>, ID extends Serializable, USERDTO extends UserDto<ID>>
+        USER extends AbstractBaseUser<ID>,
+        ID extends Serializable,
+        USERDTO extends AbstractBaseUserDto<ID>>
     extends AbstractEntityService<USER, ID, USERDTO> implements UserDetailsService {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractUserService.class);
   private static final SecureRandom SECURE_RANDOM = new SecureRandom();

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/JwtTokenService.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/JwtTokenService.java
@@ -23,7 +23,7 @@ import de.frachtwerk.essencium.backend.configuration.properties.JwtConfigPropert
 import de.frachtwerk.essencium.backend.model.AbstractBaseUser;
 import de.frachtwerk.essencium.backend.model.SessionToken;
 import de.frachtwerk.essencium.backend.model.SessionTokenType;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.model.representation.TokenRepresentation;
 import de.frachtwerk.essencium.backend.repository.SessionTokenRepository;
 import de.frachtwerk.essencium.backend.security.SessionTokenKeyLocator;
@@ -57,7 +57,7 @@ public class JwtTokenService implements Clock {
 
   @Setter
   private AbstractUserService<
-          ? extends AbstractBaseUser<?>, ? extends Serializable, ? extends UserDto<?>>
+          ? extends AbstractBaseUser<?>, ? extends Serializable, ? extends AbstractBaseUserDto<?>>
       userService;
 
   private final UserMailService userMailService;

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/RoleService.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/RoleService.java
@@ -22,8 +22,8 @@ package de.frachtwerk.essencium.backend.service;
 import de.frachtwerk.essencium.backend.model.AbstractBaseUser;
 import de.frachtwerk.essencium.backend.model.Right;
 import de.frachtwerk.essencium.backend.model.Role;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.model.dto.RoleDto;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
 import de.frachtwerk.essencium.backend.model.exception.NotAllowedException;
 import de.frachtwerk.essencium.backend.model.exception.ResourceNotFoundException;
 import de.frachtwerk.essencium.backend.model.exception.ResourceUpdateException;
@@ -52,7 +52,7 @@ public class RoleService {
 
   @Setter
   protected AbstractUserService<
-          ? extends AbstractBaseUser<?>, ? extends Serializable, ? extends UserDto<?>>
+          ? extends AbstractBaseUser<?>, ? extends Serializable, ? extends AbstractBaseUserDto<?>>
       userService;
 
   public List<Role> getAll() {

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/api/data/extension/TestObjectInjectionExtension.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/api/data/extension/TestObjectInjectionExtension.java
@@ -6,7 +6,7 @@ import de.frachtwerk.essencium.backend.api.annotations.*;
 import de.frachtwerk.essencium.backend.api.data.TestObjects;
 import de.frachtwerk.essencium.backend.api.data.user.UserStub;
 import de.frachtwerk.essencium.backend.model.Role;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import java.lang.reflect.Parameter;
 import java.util.List;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -25,7 +25,7 @@ public class TestObjectInjectionExtension implements ParameterResolver {
     Parameter parameter = parameterContext.getParameter();
 
     return List.of(
-            UserDto.class,
+            AbstractBaseUserDto.class,
             UserStub.class,
             UsernamePasswordAuthenticationToken.class,
             Pageable.class,
@@ -40,7 +40,7 @@ public class TestObjectInjectionExtension implements ParameterResolver {
       throws ParameterResolutionException {
     Parameter parameter = parameterContext.getParameter();
 
-    if (parameter.getType().equals(UserDto.class)) {
+    if (parameter.getType().equals(AbstractBaseUserDto.class)) {
       return TestObjects.users().userDtoBuilder().buildDefaultUserDto();
     }
     if (parameter.getType().equals(UserStub.class)) {

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/api/data/service/UserServiceStub.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/api/data/service/UserServiceStub.java
@@ -21,7 +21,7 @@ package de.frachtwerk.essencium.backend.api.data.service;
 
 import de.frachtwerk.essencium.backend.api.data.user.UserStub;
 import de.frachtwerk.essencium.backend.model.Role;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.repository.BaseUserRepository;
 import de.frachtwerk.essencium.backend.service.AbstractUserService;
 import de.frachtwerk.essencium.backend.service.AdminRightRoleCache;
@@ -33,7 +33,8 @@ import java.util.HashSet;
 import java.util.stream.Collectors;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-public class UserServiceStub extends AbstractUserService<UserStub, Long, UserDto<Long>> {
+public class UserServiceStub
+    extends AbstractUserService<UserStub, Long, AbstractBaseUserDto<Long>> {
 
   public <T extends RoleService> UserServiceStub(
       @NotNull BaseUserRepository<UserStub, Long> userRepository,
@@ -52,7 +53,8 @@ public class UserServiceStub extends AbstractUserService<UserStub, Long, UserDto
   }
 
   @Override
-  public @NotNull <E extends UserDto<Long>> UserStub convertDtoToEntity(@NotNull E entity) {
+  public @NotNull <E extends AbstractBaseUserDto<Long>> UserStub convertDtoToEntity(
+      @NotNull E entity) {
     HashSet<Role> roles =
         entity.getRoles().stream()
             .map(roleService::getByName)
@@ -73,7 +75,7 @@ public class UserServiceStub extends AbstractUserService<UserStub, Long, UserDto
   }
 
   @Override
-  public UserDto<Long> getNewUser() {
-    return new UserDto<>();
+  public AbstractBaseUserDto<Long> getNewUser() {
+    return new AbstractBaseUserDto<>();
   }
 }

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/api/data/service/UserServiceStubUUID.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/api/data/service/UserServiceStubUUID.java
@@ -21,7 +21,7 @@ package de.frachtwerk.essencium.backend.api.data.service;
 
 import de.frachtwerk.essencium.backend.api.data.user.TestUUIDUser;
 import de.frachtwerk.essencium.backend.model.Role;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.repository.BaseUserRepository;
 import de.frachtwerk.essencium.backend.service.AbstractUserService;
 import de.frachtwerk.essencium.backend.service.AdminRightRoleCache;
@@ -34,7 +34,8 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-public class UserServiceStubUUID extends AbstractUserService<TestUUIDUser, UUID, UserDto<UUID>> {
+public class UserServiceStubUUID
+    extends AbstractUserService<TestUUIDUser, UUID, AbstractBaseUserDto<UUID>> {
 
   public <T extends RoleService> UserServiceStubUUID(
       @NotNull BaseUserRepository<TestUUIDUser, UUID> userRepository,
@@ -53,7 +54,8 @@ public class UserServiceStubUUID extends AbstractUserService<TestUUIDUser, UUID,
   }
 
   @Override
-  public @NotNull <E extends UserDto<UUID>> TestUUIDUser convertDtoToEntity(@NotNull E entity) {
+  public @NotNull <E extends AbstractBaseUserDto<UUID>> TestUUIDUser convertDtoToEntity(
+      @NotNull E entity) {
     HashSet<Role> roles =
         entity.getRoles().stream()
             .map(roleService::getByName)
@@ -74,7 +76,7 @@ public class UserServiceStubUUID extends AbstractUserService<TestUUIDUser, UUID,
   }
 
   @Override
-  public UserDto<UUID> getNewUser() {
-    return new UserDto<>();
+  public AbstractBaseUserDto<UUID> getNewUser() {
+    return new AbstractBaseUserDto<>();
   }
 }

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/api/data/user/TestObjectsUser.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/api/data/user/TestObjectsUser.java
@@ -1,7 +1,7 @@
 package de.frachtwerk.essencium.backend.api.data.user;
 
 import de.frachtwerk.essencium.backend.model.AbstractBaseUser;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import java.util.Locale;
 import java.util.UUID;
 
@@ -60,7 +60,7 @@ public class TestObjectsUser {
     return new UserDtoBuilder();
   }
 
-  public UserDto<Long> defaultUserUpdateDto() {
+  public AbstractBaseUserDto<Long> defaultUserUpdateDto() {
     final String NEW_FIRST_NAME = "Robin";
     final String NEW_LAST_NAME = "The Ripper";
     final String NEW_PHONE = "018012345";
@@ -68,7 +68,7 @@ public class TestObjectsUser {
     final Locale NEW_LOCALE = Locale.ITALY;
     final String NEW_PASSWORD = "hopefully not working!";
 
-    final UserDto<Long> updates = new UserDto<>();
+    final AbstractBaseUserDto<Long> updates = new AbstractBaseUserDto<>();
     updates.setFirstName(NEW_FIRST_NAME);
     updates.setLastName(NEW_LAST_NAME);
     updates.setPhone(NEW_PHONE);

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/api/data/user/UserDtoBuilder.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/api/data/user/UserDtoBuilder.java
@@ -1,6 +1,6 @@
 package de.frachtwerk.essencium.backend.api.data.user;
 
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -36,8 +36,8 @@ public class UserDtoBuilder {
     return this;
   }
 
-  public UserDto<Long> buildDefaultUserDto() {
-    UserDto<Long> userDto = new UserDto<>();
+  public AbstractBaseUserDto<Long> buildDefaultUserDto() {
+    AbstractBaseUserDto<Long> userDto = new AbstractBaseUserDto<>();
 
     userDto.setId(1L);
     userDto.setEmail(this.email);

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/configuration/initialization/DefaultLongUserInitializerTest.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/configuration/initialization/DefaultLongUserInitializerTest.java
@@ -25,7 +25,7 @@ import de.frachtwerk.essencium.backend.api.data.user.UserStub;
 import de.frachtwerk.essencium.backend.configuration.properties.InitProperties;
 import de.frachtwerk.essencium.backend.configuration.properties.UserProperties;
 import de.frachtwerk.essencium.backend.model.*;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.service.AbstractUserService;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -38,7 +38,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class DefaultLongUserInitializerTest {
-  @Mock AbstractUserService<UserStub, Long, UserDto<Long>> userServiceMock;
+  @Mock AbstractUserService<UserStub, Long, AbstractBaseUserDto<Long>> userServiceMock;
   private InitProperties initProperties;
   private Random random;
 
@@ -59,10 +59,10 @@ class DefaultLongUserInitializerTest {
     List<UserStub> userDB = new ArrayList<>();
 
     when(userServiceMock.getAll()).thenReturn(userDB);
-    when(userServiceMock.create(any(UserDto.class)))
+    when(userServiceMock.create(any(AbstractBaseUserDto.class)))
         .thenAnswer(
             invocation -> {
-              UserDto<UUID> entity = invocation.getArgument(0);
+              AbstractBaseUserDto<UUID> entity = invocation.getArgument(0);
               UserStub user =
                   UserStub.builder()
                       .email(entity.getEmail())
@@ -82,9 +82,9 @@ class DefaultLongUserInitializerTest {
               userDB.add(user);
               return user;
             });
-    when(userServiceMock.getNewUser()).thenReturn(new UserDto<>());
+    when(userServiceMock.getNewUser()).thenReturn(new AbstractBaseUserDto<>());
 
-    DefaultUserInitializer<UserStub, UserDto<Long>, Long> SUT =
+    DefaultUserInitializer<UserStub, AbstractBaseUserDto<Long>, Long> SUT =
         new DefaultUserInitializer<>(userServiceMock, initProperties);
 
     SUT.run();
@@ -95,7 +95,7 @@ class DefaultLongUserInitializerTest {
 
     verify(userServiceMock, times(1)).getAll();
     verify(userServiceMock, times(2)).getNewUser();
-    verify(userServiceMock, times(2)).create(any(UserDto.class));
+    verify(userServiceMock, times(2)).create(any(AbstractBaseUserDto.class));
 
     verifyNoMoreInteractions(userServiceMock);
   }
@@ -122,10 +122,10 @@ class DefaultLongUserInitializerTest {
             .build());
 
     when(userServiceMock.getAll()).thenReturn(userDB);
-    when(userServiceMock.create(any(UserDto.class)))
+    when(userServiceMock.create(any(AbstractBaseUserDto.class)))
         .thenAnswer(
             invocation -> {
-              UserDto<UUID> entity = invocation.getArgument(0);
+              AbstractBaseUserDto<UUID> entity = invocation.getArgument(0);
               UserStub user =
                   UserStub.builder()
                       .email(entity.getEmail())
@@ -145,9 +145,9 @@ class DefaultLongUserInitializerTest {
               userDB.add(user);
               return user;
             });
-    when(userServiceMock.getNewUser()).thenReturn(new UserDto<>());
+    when(userServiceMock.getNewUser()).thenReturn(new AbstractBaseUserDto<>());
 
-    DefaultUserInitializer<UserStub, UserDto<Long>, Long> SUT =
+    DefaultUserInitializer<UserStub, AbstractBaseUserDto<Long>, Long> SUT =
         new DefaultUserInitializer<>(userServiceMock, initProperties);
     SUT.run();
 
@@ -157,7 +157,7 @@ class DefaultLongUserInitializerTest {
 
     verify(userServiceMock, times(1)).getAll();
     verify(userServiceMock, times(1)).getNewUser();
-    verify(userServiceMock, times(1)).create(any(UserDto.class));
+    verify(userServiceMock, times(1)).create(any(AbstractBaseUserDto.class));
     verify(userServiceMock, times(1)).patch(anyLong(), anyMap());
 
     verifyNoMoreInteractions(userServiceMock);

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/configuration/initialization/DefaultUUIDUserInitializerTest.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/configuration/initialization/DefaultUUIDUserInitializerTest.java
@@ -30,7 +30,7 @@ import de.frachtwerk.essencium.backend.configuration.properties.InitProperties;
 import de.frachtwerk.essencium.backend.configuration.properties.UserProperties;
 import de.frachtwerk.essencium.backend.model.*;
 import de.frachtwerk.essencium.backend.model.Role;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.service.AbstractUserService;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -42,7 +42,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class DefaultUUIDUserInitializerTest {
-  @Mock AbstractUserService<TestUUIDUser, UUID, UserDto<UUID>> userServiceMock;
+  @Mock AbstractUserService<TestUUIDUser, UUID, AbstractBaseUserDto<UUID>> userServiceMock;
   private InitProperties initProperties;
 
   @BeforeEach
@@ -61,10 +61,10 @@ class DefaultUUIDUserInitializerTest {
     List<TestUUIDUser> userDB = new ArrayList<>();
 
     when(userServiceMock.getAll()).thenReturn(userDB);
-    when(userServiceMock.create(any(UserDto.class)))
+    when(userServiceMock.create(any(AbstractBaseUserDto.class)))
         .thenAnswer(
             invocation -> {
-              UserDto<UUID> entity = invocation.getArgument(0);
+              AbstractBaseUserDto<UUID> entity = invocation.getArgument(0);
               TestUUIDUser user =
                   TestUUIDUser.builder()
                       .email(entity.getEmail())
@@ -84,9 +84,9 @@ class DefaultUUIDUserInitializerTest {
               userDB.add(user);
               return user;
             });
-    when(userServiceMock.getNewUser()).thenReturn(new UserDto<>());
+    when(userServiceMock.getNewUser()).thenReturn(new AbstractBaseUserDto<>());
 
-    DefaultUserInitializer<TestUUIDUser, UserDto<UUID>, UUID> SUT =
+    DefaultUserInitializer<TestUUIDUser, AbstractBaseUserDto<UUID>, UUID> SUT =
         new DefaultUserInitializer<>(userServiceMock, initProperties);
     SUT.run();
 
@@ -119,10 +119,10 @@ class DefaultUUIDUserInitializerTest {
             .build());
 
     when(userServiceMock.getAll()).thenReturn(userDB);
-    when(userServiceMock.create(any(UserDto.class)))
+    when(userServiceMock.create(any(AbstractBaseUserDto.class)))
         .thenAnswer(
             invocation -> {
-              UserDto<UUID> entity = invocation.getArgument(0);
+              AbstractBaseUserDto<UUID> entity = invocation.getArgument(0);
               TestUUIDUser user =
                   TestUUIDUser.builder()
                       .email(entity.getEmail())
@@ -142,9 +142,9 @@ class DefaultUUIDUserInitializerTest {
               userDB.add(user);
               return user;
             });
-    when(userServiceMock.getNewUser()).thenReturn(new UserDto<>());
+    when(userServiceMock.getNewUser()).thenReturn(new AbstractBaseUserDto<>());
 
-    DefaultUserInitializer<TestUUIDUser, UserDto<UUID>, UUID> SUT =
+    DefaultUserInitializer<TestUUIDUser, AbstractBaseUserDto<UUID>, UUID> SUT =
         new DefaultUserInitializer<>(userServiceMock, initProperties);
     SUT.run();
 
@@ -154,7 +154,7 @@ class DefaultUUIDUserInitializerTest {
 
     verify(userServiceMock, times(1)).getAll();
     verify(userServiceMock, times(1)).getNewUser();
-    verify(userServiceMock, times(1)).create(any(UserDto.class));
+    verify(userServiceMock, times(1)).create(any(AbstractBaseUserDto.class));
     verify(userServiceMock, times(1)).patch(any(UUID.class), anyMap());
 
     verifyNoMoreInteractions(userServiceMock);

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/LongResetCredentialsControllerTest.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/LongResetCredentialsControllerTest.java
@@ -23,17 +23,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import de.frachtwerk.essencium.backend.api.data.user.UserStub;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.model.dto.PasswordUpdateRequest;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
 import de.frachtwerk.essencium.backend.service.AbstractUserService;
 import org.junit.jupiter.api.Test;
 
 class LongResetCredentialsControllerTest {
 
-  private final AbstractUserService<UserStub, Long, UserDto<Long>> userServiceMock =
+  private final AbstractUserService<UserStub, Long, AbstractBaseUserDto<Long>> userServiceMock =
       mock(AbstractUserService.class);
 
-  private final ResetCredentialsController<UserStub, Long, UserDto<Long>> testSubject =
+  private final ResetCredentialsController<UserStub, Long, AbstractBaseUserDto<Long>> testSubject =
       new ResetCredentialsController(userServiceMock);
 
   @Test

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/LongUserController.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/LongUserController.java
@@ -22,12 +22,12 @@ package de.frachtwerk.essencium.backend.controller;
 import de.frachtwerk.essencium.backend.api.data.service.UserServiceStub;
 import de.frachtwerk.essencium.backend.api.data.user.UserStub;
 import de.frachtwerk.essencium.backend.model.assembler.LongUserAssembler;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.repository.specification.BaseUserSpec;
 
 public class LongUserController
     extends AbstractUserController<
-        UserStub, UserStub, UserDto<Long>, BaseUserSpec<UserStub, Long>, Long> {
+        UserStub, UserStub, AbstractBaseUserDto<Long>, BaseUserSpec<UserStub, Long>, Long> {
 
   protected LongUserController(UserServiceStub userService, LongUserAssembler assembler) {
     super(userService, assembler);

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/LongUserControllerTest.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/LongUserControllerTest.java
@@ -29,7 +29,7 @@ import de.frachtwerk.essencium.backend.api.data.user.UserStub;
 import de.frachtwerk.essencium.backend.model.SessionToken;
 import de.frachtwerk.essencium.backend.model.SessionTokenType;
 import de.frachtwerk.essencium.backend.model.assembler.LongUserAssembler;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.model.exception.DuplicateResourceException;
 import de.frachtwerk.essencium.backend.model.representation.TokenRepresentation;
 import de.frachtwerk.essencium.backend.repository.specification.BaseUserSpec;
@@ -91,7 +91,7 @@ class LongUserControllerTest {
   @Test
   void create() {
     final var newUserEmail = "user@example.com";
-    var testCreationUser = Mockito.mock(UserDto.class);
+    var testCreationUser = Mockito.mock(AbstractBaseUserDto.class);
     when(testCreationUser.getEmail()).thenReturn(newUserEmail);
 
     var createdUserMock = Mockito.mock(UserStub.class);
@@ -109,7 +109,7 @@ class LongUserControllerTest {
   @Test
   void createAlreadyExisting() {
     final var newUserEmail = "user@example.com";
-    var testCreationUser = Mockito.mock(UserDto.class);
+    var testCreationUser = Mockito.mock(AbstractBaseUserDto.class);
     when(testCreationUser.getEmail()).thenReturn(newUserEmail);
 
     Mockito.when(userServiceMock.loadUserByUsername(anyString()))
@@ -124,7 +124,7 @@ class LongUserControllerTest {
   @Test
   void updateObject() {
     var testId = 42L;
-    var testUpdateUser = Mockito.mock(UserDto.class);
+    var testUpdateUser = Mockito.mock(AbstractBaseUserDto.class);
     var updatedUserMock = Mockito.mock(UserStub.class);
     BaseUserSpec testSpecification = Mockito.mock(BaseUserSpec.class);
 
@@ -216,7 +216,7 @@ class LongUserControllerTest {
 
   @Test
   void updateCurrentLoggedInUser() {
-    UserDto updateUserMock = mock(UserDto.class);
+    AbstractBaseUserDto updateUserMock = mock(AbstractBaseUserDto.class);
     UserStub persistedUserMock = mock(UserStub.class);
 
     when(userServiceMock.selfUpdate(persistedUserMock, updateUserMock))

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/UUIDResetCredentialsControllerTest.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/UUIDResetCredentialsControllerTest.java
@@ -25,19 +25,19 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import de.frachtwerk.essencium.backend.api.data.user.TestUUIDUser;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.model.dto.PasswordUpdateRequest;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
 import de.frachtwerk.essencium.backend.service.AbstractUserService;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 class UUIDResetCredentialsControllerTest {
 
-  private final AbstractUserService<TestUUIDUser, UUID, UserDto<UUID>> userServiceMock =
+  private final AbstractUserService<TestUUIDUser, UUID, AbstractBaseUserDto<UUID>> userServiceMock =
       mock(AbstractUserService.class);
 
-  private final ResetCredentialsController<TestUUIDUser, UUID, UserDto<UUID>> testSubject =
-      new ResetCredentialsController(userServiceMock);
+  private final ResetCredentialsController<TestUUIDUser, UUID, AbstractBaseUserDto<UUID>>
+      testSubject = new ResetCredentialsController(userServiceMock);
 
   @Test
   void requestResetToken() {

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/UUIDUserController.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/UUIDUserController.java
@@ -22,13 +22,17 @@ package de.frachtwerk.essencium.backend.controller;
 import de.frachtwerk.essencium.backend.api.data.service.UserServiceStubUUID;
 import de.frachtwerk.essencium.backend.api.data.user.TestUUIDUser;
 import de.frachtwerk.essencium.backend.model.assembler.UUIDUserAssembler;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.repository.specification.BaseUserSpec;
 import java.util.UUID;
 
 public class UUIDUserController
     extends AbstractUserController<
-        TestUUIDUser, TestUUIDUser, UserDto<UUID>, BaseUserSpec<TestUUIDUser, UUID>, UUID> {
+        TestUUIDUser,
+        TestUUIDUser,
+        AbstractBaseUserDto<UUID>,
+        BaseUserSpec<TestUUIDUser, UUID>,
+        UUID> {
 
   protected UUIDUserController(UserServiceStubUUID userService, UUIDUserAssembler assembler) {
     super(userService, assembler);

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/UUIDUserControllerTest.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/UUIDUserControllerTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.when;
 import de.frachtwerk.essencium.backend.api.data.service.UserServiceStubUUID;
 import de.frachtwerk.essencium.backend.api.data.user.TestUUIDUser;
 import de.frachtwerk.essencium.backend.model.assembler.UUIDUserAssembler;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.model.exception.DuplicateResourceException;
 import de.frachtwerk.essencium.backend.model.representation.assembler.UserRepresentationDefaultAssembler;
 import de.frachtwerk.essencium.backend.repository.specification.BaseUserSpec;
@@ -87,7 +87,7 @@ class UUIDUserControllerTest {
   @Test
   void create() {
     final var newUserEmail = "user@example.com";
-    var testCreationUser = Mockito.mock(UserDto.class);
+    var testCreationUser = Mockito.mock(AbstractBaseUserDto.class);
     when(testCreationUser.getEmail()).thenReturn(newUserEmail);
 
     var createdUserMock = Mockito.mock(TestUUIDUser.class);
@@ -105,7 +105,7 @@ class UUIDUserControllerTest {
   @Test
   void createAlreadyExisting() {
     final var newUserEmail = "user@example.com";
-    var testCreationUser = Mockito.mock(UserDto.class);
+    var testCreationUser = Mockito.mock(AbstractBaseUserDto.class);
     when(testCreationUser.getEmail()).thenReturn(newUserEmail);
 
     Mockito.when(userServiceMock.loadUserByUsername(anyString()))
@@ -120,7 +120,7 @@ class UUIDUserControllerTest {
   @Test
   void updateObject() {
     var testId = UUID.randomUUID();
-    var testUpdateUser = Mockito.mock(UserDto.class);
+    var testUpdateUser = Mockito.mock(AbstractBaseUserDto.class);
     var updatedUserMock = Mockito.mock(TestUUIDUser.class);
     BaseUserSpec testSpecification = Mockito.mock(BaseUserSpec.class);
 
@@ -212,7 +212,7 @@ class UUIDUserControllerTest {
 
   @Test
   void updateCurrentLoggedInUser() {
-    var updateUserMock = mock(UserDto.class);
+    var updateUserMock = mock(AbstractBaseUserDto.class);
     var persistedUserMock = mock(TestUUIDUser.class);
 
     when(userServiceMock.selfUpdate(persistedUserMock, updateUserMock))

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/service/ContactMailServiceTest.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/service/ContactMailServiceTest.java
@@ -31,8 +31,8 @@ import de.frachtwerk.essencium.backend.api.data.user.UserStub;
 import de.frachtwerk.essencium.backend.configuration.properties.MailConfigProperties;
 import de.frachtwerk.essencium.backend.model.AbstractBaseUser;
 import de.frachtwerk.essencium.backend.model.Mail;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.model.dto.ContactRequestDto;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
 import de.frachtwerk.essencium.backend.model.exception.InvalidInputException;
 import de.frachtwerk.essencium.backend.model.exception.ResourceNotFoundException;
 import de.frachtwerk.essencium.backend.model.mail.ContactMessageData;
@@ -52,7 +52,7 @@ import org.springframework.security.web.authentication.session.SessionAuthentica
 class ContactMailServiceTest {
 
   private final SimpleMailService mailServiceMock = mock(SimpleMailService.class);
-  private final AbstractUserService<UserStub, Long, UserDto<Long>> userServiceMock =
+  private final AbstractUserService<UserStub, Long, AbstractBaseUserDto<Long>> userServiceMock =
       mock(AbstractUserService.class);
   private final MailConfigProperties.ContactMail contactMailConfigPropertiesMock =
       mock(MailConfigProperties.ContactMail.class);

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/service/UserServiceTest.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/service/UserServiceTest.java
@@ -12,8 +12,8 @@ import de.frachtwerk.essencium.backend.api.data.service.UserServiceStub;
 import de.frachtwerk.essencium.backend.api.data.user.UserStub;
 import de.frachtwerk.essencium.backend.model.Role;
 import de.frachtwerk.essencium.backend.model.UserInfoEssentials;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.model.dto.PasswordUpdateRequest;
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
 import de.frachtwerk.essencium.backend.model.exception.NotAllowedException;
 import de.frachtwerk.essencium.backend.model.exception.ResourceNotFoundException;
 import de.frachtwerk.essencium.backend.model.exception.ResourceUpdateException;
@@ -119,7 +119,7 @@ public class UserServiceTest {
     @Test
     @DisplayName("Should create a User with a custom role from a UserDTO")
     void customRole(@TestRole(name = "SPECIAL_ROLE") Role testRole) {
-      UserDto<Long> userDto =
+      AbstractBaseUserDto<Long> userDto =
           TestObjects.users().userDtoBuilder().withRoles(testRole.getName()).buildDefaultUserDto();
 
       givenMocks(configure(userRepositoryMock).returnAlwaysPassedObjectOnSave())
@@ -137,7 +137,7 @@ public class UserServiceTest {
     @Test
     @DisplayName("Should create a User with password, where only the encoded String is present")
     void passwordPresent() {
-      UserDto<Long> userDto =
+      AbstractBaseUserDto<Long> userDto =
           TestObjects.users()
               .userDtoBuilder()
               .withPassword(TEST_PASSWORD_PLAIN)
@@ -160,7 +160,7 @@ public class UserServiceTest {
     @DisplayName(
         "Should create a new random password if password is null / empty and request is local")
     void passwordNullEmptyOrBlank(String password) {
-      UserDto<Long> userDto =
+      AbstractBaseUserDto<Long> userDto =
           TestObjects.users()
               .userDtoBuilder()
               .withPassword(password)
@@ -197,7 +197,7 @@ public class UserServiceTest {
     @DisplayName("Should not send a email if User creation source is external")
     void externalAuth() {
       final String NEW_EXTERNAL_SOURCE = "ldap";
-      UserDto<Long> userDto =
+      AbstractBaseUserDto<Long> userDto =
           TestObjects.users()
               .userDtoBuilder()
               .withEmail(TEST_USERNAME)
@@ -226,7 +226,7 @@ public class UserServiceTest {
   class UpdateUser {
     @Test
     @DisplayName("Should throw a ResourceUpdateException when updating with an inconsistent ID")
-    void inconsistentId(UserDto<Long> userDto) {
+    void inconsistentId(AbstractBaseUserDto<Long> userDto) {
       givenMocks(configure(userRepositoryMock).anotherAdminExistsInTheSystem());
 
       assertThrows(
@@ -235,7 +235,7 @@ public class UserServiceTest {
 
     @Test
     @DisplayName("Should throw a ResourceNotFoundException when updating a non existing User")
-    void userNotFound(UserDto<Long> userDto) {
+    void userNotFound(AbstractBaseUserDto<Long> userDto) {
       givenMocks(configure(userRepositoryMock).anotherAdminExistsInTheSystem());
 
       assertThrows(
@@ -244,7 +244,7 @@ public class UserServiceTest {
 
     @Test
     @DisplayName("Should update a Users password successfully")
-    void updateSuccessful(UserDto<Long> userToUpdateDto, UserStub existingUser) {
+    void updateSuccessful(AbstractBaseUserDto<Long> userToUpdateDto, UserStub existingUser) {
       userToUpdateDto.setPassword(TEST_PASSWORD_PLAIN);
 
       givenMocks(
@@ -265,7 +265,7 @@ public class UserServiceTest {
     @Test
     @DisplayName("Should not update a Users password if the User is external")
     void testNoPasswordUpdateForExternalUser(
-        UserDto<Long> userToUpdateDto,
+        AbstractBaseUserDto<Long> userToUpdateDto,
         @TestUserStub(type = TestUserStubType.EXTERNAL) UserStub existingUser) {
 
       userToUpdateDto.setPassword(TEST_PASSWORD_PLAIN);
@@ -727,7 +727,7 @@ public class UserServiceTest {
 
     @Test
     @DisplayName("Should throw a RuntimeException if self update a null User")
-    void testExceptionOnNullUser(UserDto<Long> userDto) {
+    void testExceptionOnNullUser(AbstractBaseUserDto<Long> userDto) {
       assertThrows(RuntimeException.class, () -> testSubject.selfUpdate(null, userDto));
     }
 
@@ -735,7 +735,7 @@ public class UserServiceTest {
     @DisplayName("Should self update the logged in User by DTO")
     void testUpdateUserByDto(
         UserStub existingUser, UsernamePasswordAuthenticationToken loggedInPrincipal) {
-      UserDto<Long> updateDto = TestObjects.users().defaultUserUpdateDto();
+      AbstractBaseUserDto<Long> updateDto = TestObjects.users().defaultUserUpdateDto();
 
       givenMocks(configure(userRepositoryMock).returnAlwaysPassedObjectOnSave());
 
@@ -759,7 +759,7 @@ public class UserServiceTest {
     @DisplayName("Should self update the logged in User by fields")
     void testUpdateUserByFields(
         UserStub existingUser, UsernamePasswordAuthenticationToken loggedInPrincipal) {
-      UserDto<Long> updateDto = TestObjects.users().defaultUserUpdateDto();
+      AbstractBaseUserDto<Long> updateDto = TestObjects.users().defaultUserUpdateDto();
 
       PATCH_FIELDS.putAll(
           Map.of(

--- a/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/AuthenticationControllerIntegrationTest.java
+++ b/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/AuthenticationControllerIntegrationTest.java
@@ -37,7 +37,7 @@ import de.frachtwerk.essencium.backend.model.Role;
 import de.frachtwerk.essencium.backend.model.dto.LoginRequest;
 import de.frachtwerk.essencium.backend.service.RoleService;
 import de.frachtwerk.essencium.backend.test.integration.model.TestUser;
-import de.frachtwerk.essencium.backend.test.integration.model.dto.TestUserDto;
+import de.frachtwerk.essencium.backend.test.integration.model.dto.TestAbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.test.integration.repository.TestBaseUserRepository;
 import de.frachtwerk.essencium.backend.test.integration.util.TestingUtils;
 import de.frachtwerk.essencium.backend.test.integration.util.extension.WireMockExtension;
@@ -142,7 +142,7 @@ public class AuthenticationControllerIntegrationTest {
               testingUtils.createUser(testingUtils.getRandomUser())));
       testingUtils.clearUsers();
       testingUtils.createUser(
-          TestUserDto.builder()
+          TestAbstractBaseUserDto.builder()
               .email(TEST_LDAP_EXISTING_USERNAME)
               .firstName(TEST_LDAP_EXISTING_FIRST_NAME)
               .lastName(TEST_LDAP_EXISTING_LAST_NAME)
@@ -441,7 +441,7 @@ public class AuthenticationControllerIntegrationTest {
       testingUtils.clearUsers();
       testUser =
           testingUtils.createUser(
-              TestUserDto.builder()
+              TestAbstractBaseUserDto.builder()
                   .email(TEST_OAUTH_EXISTING_USERNAME)
                   .firstName(TEST_OAUTH_EXISTING_FIRST_NAME)
                   .lastName(TEST_OAUTH_EXISTING_LAST_NAME)

--- a/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/TestUserController.java
+++ b/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/TestUserController.java
@@ -23,14 +23,14 @@ import de.frachtwerk.essencium.backend.controller.AbstractUserController;
 import de.frachtwerk.essencium.backend.repository.specification.BaseUserSpec;
 import de.frachtwerk.essencium.backend.test.integration.model.TestUser;
 import de.frachtwerk.essencium.backend.test.integration.model.assembler.TestUserAssembler;
-import de.frachtwerk.essencium.backend.test.integration.model.dto.TestUserDto;
+import de.frachtwerk.essencium.backend.test.integration.model.dto.TestAbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.test.integration.service.TestUserService;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class TestUserController
     extends AbstractUserController<
-        TestUser, TestUser, TestUserDto, BaseUserSpec<TestUser, Long>, Long> {
+        TestUser, TestUser, TestAbstractBaseUserDto, BaseUserSpec<TestUser, Long>, Long> {
 
   protected TestUserController(TestUserService userService, TestUserAssembler assembler) {
     super(userService, assembler);

--- a/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/UserControllerIntegrationTest.java
+++ b/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/UserControllerIntegrationTest.java
@@ -40,7 +40,7 @@ import de.frachtwerk.essencium.backend.model.Role;
 import de.frachtwerk.essencium.backend.model.dto.PasswordUpdateRequest;
 import de.frachtwerk.essencium.backend.test.integration.IntegrationTestApplication;
 import de.frachtwerk.essencium.backend.test.integration.model.TestUser;
-import de.frachtwerk.essencium.backend.test.integration.model.dto.TestUserDto;
+import de.frachtwerk.essencium.backend.test.integration.model.dto.TestAbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.test.integration.repository.TestBaseUserRepository;
 import de.frachtwerk.essencium.backend.test.integration.util.TestingUtils;
 import jakarta.servlet.ServletContext;
@@ -342,7 +342,7 @@ class UserControllerIntegrationTest {
     String newMobile = "01234567889";
     String newPhone = "0123456789";
 
-    TestUserDto content = new TestUserDto();
+    TestAbstractBaseUserDto content = new TestAbstractBaseUserDto();
     content.setId(testUser.getId());
     content.setFirstName(newFirstName);
     content.setLastName(newLastName);
@@ -387,7 +387,7 @@ class UserControllerIntegrationTest {
     String newMobile = "01234567889";
     String newPhone = "0123456789";
 
-    TestUserDto content = new TestUserDto();
+    TestAbstractBaseUserDto content = new TestAbstractBaseUserDto();
     content.setId(adminUser.getId());
     content.setFirstName(newFirstName);
     content.setLastName(newLastName);
@@ -435,7 +435,7 @@ class UserControllerIntegrationTest {
     String newMobile = "01234567889";
     String newPhone = "0123456789";
 
-    TestUserDto content = new TestUserDto();
+    TestAbstractBaseUserDto content = new TestAbstractBaseUserDto();
     content.setId(secondAdmin.getId());
     content.setFirstName(newFirstName);
     content.setLastName(newLastName);
@@ -558,7 +558,7 @@ class UserControllerIntegrationTest {
 
   @Test
   void testUpdateSelfByDto() throws Exception {
-    final TestUserDto updateDto = new TestUserDto();
+    final TestAbstractBaseUserDto updateDto = new TestAbstractBaseUserDto();
     updateDto.setFirstName("Elon");
     updateDto.setLastName("Musk");
     updateDto.setPhone("0123456");
@@ -606,7 +606,7 @@ class UserControllerIntegrationTest {
 
   @Test
   void testUpdateSelfWithMissingProperties() throws Exception {
-    final TestUserDto updateDto = new TestUserDto();
+    final TestAbstractBaseUserDto updateDto = new TestAbstractBaseUserDto();
     updateDto.setFirstName("Elon"); // lastName missing
 
     final String updateJson = objectMapper.writeValueAsString(updateDto);
@@ -640,7 +640,7 @@ class UserControllerIntegrationTest {
     final ObjectMapper localOm =
         JsonMapper.builder().configure(MapperFeature.USE_ANNOTATIONS, false).build();
 
-    TestUserDto dto = testingUtils.getRandomUser();
+    TestAbstractBaseUserDto dto = testingUtils.getRandomUser();
     TestUser localTestUser = testingUtils.createUser(dto);
 
     dto.setId(localTestUser.getId());
@@ -662,7 +662,7 @@ class UserControllerIntegrationTest {
             .configure(MapperFeature.USE_ANNOTATIONS, false)
             .build(); // otherwise, 'password' field won't be serialized
 
-    TestUserDto dto = testingUtils.getRandomUser();
+    TestAbstractBaseUserDto dto = testingUtils.getRandomUser();
     TestUser localTestUser = testingUtils.createUser(dto);
 
     dto.setId(localTestUser.getId());
@@ -750,7 +750,7 @@ class UserControllerIntegrationTest {
 
   @Test
   void testCreateUser() throws Exception {
-    final TestUserDto dto = testingUtils.getRandomUser();
+    final TestAbstractBaseUserDto dto = testingUtils.getRandomUser();
 
     mockMvc
         .perform(
@@ -766,7 +766,7 @@ class UserControllerIntegrationTest {
     final ObjectMapper localOm =
         JsonMapper.builder().configure(MapperFeature.USE_ANNOTATIONS, false).build();
 
-    final TestUserDto dto = testingUtils.getRandomUser();
+    final TestAbstractBaseUserDto dto = testingUtils.getRandomUser();
     dto.setPassword("a");
 
     mockMvc

--- a/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/model/dto/TestAbstractBaseUserDto.java
+++ b/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/model/dto/TestAbstractBaseUserDto.java
@@ -1,6 +1,6 @@
 package de.frachtwerk.essencium.backend.test.integration.model.dto;
 
-import de.frachtwerk.essencium.backend.model.dto.UserDto;
+import de.frachtwerk.essencium.backend.model.dto.AbstractBaseUserDto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -10,4 +10,4 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @SuperBuilder(toBuilder = true)
 @Data
-public class TestUserDto extends UserDto<Long> {}
+public class TestAbstractBaseUserDto extends AbstractBaseUserDto<Long> {}

--- a/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/security/oauth2/OAuth2SuccessHandlerTest.java
+++ b/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/security/oauth2/OAuth2SuccessHandlerTest.java
@@ -31,7 +31,7 @@ import de.frachtwerk.essencium.backend.security.oauth2.util.CookieUtil;
 import de.frachtwerk.essencium.backend.service.JwtTokenService;
 import de.frachtwerk.essencium.backend.service.RoleService;
 import de.frachtwerk.essencium.backend.test.integration.model.TestUser;
-import de.frachtwerk.essencium.backend.test.integration.model.dto.TestUserDto;
+import de.frachtwerk.essencium.backend.test.integration.model.dto.TestAbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.test.integration.service.TestUserService;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -59,7 +59,7 @@ class OAuth2SuccessHandlerTest {
   void testOnAuthenticationSuccessDoNothingWithoutUserEmail() throws ServletException, IOException {
     OAuth2ConfigProperties oAuth2ConfigProperties = new OAuth2ConfigProperties();
 
-    OAuth2SuccessHandler<TestUser, Long, TestUserDto> oAuth2SuccessHandler =
+    OAuth2SuccessHandler<TestUser, Long, TestAbstractBaseUserDto> oAuth2SuccessHandler =
         new OAuth2SuccessHandler<>(
             tokenServiceMock,
             userServiceMock,
@@ -105,7 +105,7 @@ class OAuth2SuccessHandlerTest {
     oAuth2ConfigProperties.setAllowSignup(true);
     oAuth2ConfigProperties.setDefaultRedirectUrl("http://localhost:8080");
 
-    OAuth2SuccessHandler<TestUser, Long, TestUserDto> oAuth2SuccessHandler =
+    OAuth2SuccessHandler<TestUser, Long, TestAbstractBaseUserDto> oAuth2SuccessHandler =
         new OAuth2SuccessHandler<>(
             tokenServiceMock,
             userServiceMock,
@@ -168,7 +168,7 @@ class OAuth2SuccessHandlerTest {
     OAuth2ConfigProperties oAuth2ConfigProperties = new OAuth2ConfigProperties();
     oAuth2ConfigProperties.setAllowSignup(true);
 
-    OAuth2SuccessHandler<TestUser, Long, TestUserDto> oAuth2SuccessHandler =
+    OAuth2SuccessHandler<TestUser, Long, TestAbstractBaseUserDto> oAuth2SuccessHandler =
         new OAuth2SuccessHandler<>(
             tokenServiceMock,
             userServiceMock,
@@ -230,7 +230,7 @@ class OAuth2SuccessHandlerTest {
     OAuth2ConfigProperties oAuth2ConfigProperties = new OAuth2ConfigProperties();
     oAuth2ConfigProperties.setAllowSignup(true);
 
-    OAuth2SuccessHandler<TestUser, Long, TestUserDto> oAuth2SuccessHandler =
+    OAuth2SuccessHandler<TestUser, Long, TestAbstractBaseUserDto> oAuth2SuccessHandler =
         new OAuth2SuccessHandler<>(
             tokenServiceMock,
             userServiceMock,

--- a/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/service/TestUserService.java
+++ b/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/service/TestUserService.java
@@ -26,7 +26,7 @@ import de.frachtwerk.essencium.backend.service.JwtTokenService;
 import de.frachtwerk.essencium.backend.service.RoleService;
 import de.frachtwerk.essencium.backend.service.UserMailService;
 import de.frachtwerk.essencium.backend.test.integration.model.TestUser;
-import de.frachtwerk.essencium.backend.test.integration.model.dto.TestUserDto;
+import de.frachtwerk.essencium.backend.test.integration.model.dto.TestAbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.test.integration.repository.TestBaseUserRepository;
 import jakarta.validation.constraints.NotNull;
 import java.util.HashSet;
@@ -35,7 +35,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
-public class TestUserService extends AbstractUserService<TestUser, Long, TestUserDto> {
+public class TestUserService extends AbstractUserService<TestUser, Long, TestAbstractBaseUserDto> {
 
   protected TestUserService(
       @NotNull TestBaseUserRepository userRepository,
@@ -54,7 +54,7 @@ public class TestUserService extends AbstractUserService<TestUser, Long, TestUse
   }
 
   @Override
-  protected @NotNull <E extends TestUserDto> TestUser convertDtoToEntity(@NotNull E entity) {
+  protected @NotNull <E extends TestAbstractBaseUserDto> TestUser convertDtoToEntity(@NotNull E entity) {
     HashSet<Role> roles =
         entity.getRoles().stream()
             .map(roleService::getByName)
@@ -74,7 +74,7 @@ public class TestUserService extends AbstractUserService<TestUser, Long, TestUse
   }
 
   @Override
-  public TestUserDto getNewUser() {
-    return new TestUserDto();
+  public TestAbstractBaseUserDto getNewUser() {
+    return new TestAbstractBaseUserDto();
   }
 }

--- a/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/util/TestingUtils.java
+++ b/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/util/TestingUtils.java
@@ -34,7 +34,7 @@ import de.frachtwerk.essencium.backend.model.exception.ResourceNotFoundException
 import de.frachtwerk.essencium.backend.repository.RightRepository;
 import de.frachtwerk.essencium.backend.repository.RoleRepository;
 import de.frachtwerk.essencium.backend.test.integration.model.TestUser;
-import de.frachtwerk.essencium.backend.test.integration.model.dto.TestUserDto;
+import de.frachtwerk.essencium.backend.test.integration.model.dto.TestAbstractBaseUserDto;
 import de.frachtwerk.essencium.backend.test.integration.service.TestUserService;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
@@ -111,7 +111,7 @@ public class TestingUtils {
       @NotNull Role role) {
     final String sanitizedUsername =
         Objects.requireNonNullElseGet(username, TestingUtils::randomUsername);
-    TestUserDto user = new TestUserDto();
+    TestAbstractBaseUserDto user = new TestAbstractBaseUserDto();
     user.setEnabled(true);
     user.setEmail(sanitizedUsername);
     user.setPassword(DEFAULT_PASSWORD);
@@ -122,14 +122,14 @@ public class TestingUtils {
     return createUser(user);
   }
 
-  public TestUser createUser(TestUserDto user) {
+  public TestUser createUser(TestAbstractBaseUserDto user) {
     final TestUser createdUser = userService.create(user);
     registry.add(createdUser.getId());
     return createdUser;
   }
 
-  public TestUserDto getRandomUser() {
-    return TestUserDto.builder()
+  public TestAbstractBaseUserDto getRandomUser() {
+    return TestAbstractBaseUserDto.builder()
         .email(randomUsername())
         .enabled(true)
         .password(DEFAULT_PASSWORD)


### PR DESCRIPTION
Renamed UserDto class to AbstractBaseUserDto

* Although the AbstractBaseUserDto class is not defined as an abstract class, I believe it should be named as abstract. This is because in our context the dto class is used to transport data of the AbstractBaseUser class. Naming the dto class also abstract should avoid any misinterpretations that this dto refers to a class other than the AbstractBaseUser.