### PR TITLE
fix: 390-handling-property-reference-exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Version `______`
 
-- Feature: `BasicRepresentation` can be used to create slim representations of entities. `BasicRepresentation` is very well suited for filling embedded objects or lists of objects in other representations.
-- Feature: Each Controller now has a `GET .../basic` endpoint that returns a List of BasicRepresentations of the entity. Filtering via Specifications is possible
+- Feature: `BasicRepresentation` can be used to create slim representations of entities. `BasicRepresentation` is very
+  well suited for filling embedded objects or lists of objects in other representations.
+- Feature: Each Controller now has a `GET .../basic` endpoint that returns a List of BasicRepresentations of the entity.
+  Filtering via Specifications is possible
 - Feature: `AbstractUserController` can now filter users by using a substring of an email.
+- fix: Invalid values for the sort query, resulting in PropertyReferenceException are handled by an ExceptionHandler and
+  result in a "Bad Request" response.
 - upgraded io.sentry:sentry-spring-boot-starter-jakarta from 7.12.0 to 7.14.0
 - upgraded org.hibernate.orm:hibernate-jpamodelgen from 6.5.2.Final to 6.6.0.Final
 - upgraded commons-logging:commons-logging from 1.3.3 to 1.3.4
@@ -12,9 +16,13 @@
 
 ## Version `2.7.0`
 
-- Feature: `AbstractUserController` now allows to test access to specific database entries before executing the actual request. This is done by using the `testAccess(<Specification>)` method provided by the `AbstractUserService`. This functionality has already been implemented and tested in the `AbstractAccessAwareController`.
-- fix: Prevent NullPointerException in OAuth2SuccessHandler/AbstractUserService when OAuth-mapped internal role is not found
-- fix: Avoid calling DaoAuthenticationProvider on every request, which calls BCryptPasswordEncoder every time and causes performance problems.
+- Feature: `AbstractUserController` now allows to test access to specific database entries before executing the actual
+  request. This is done by using the `testAccess(<Specification>)` method provided by the `AbstractUserService`. This
+  functionality has already been implemented and tested in the `AbstractAccessAwareController`.
+- fix: Prevent NullPointerException in OAuth2SuccessHandler/AbstractUserService when OAuth-mapped internal role is not
+  found
+- fix: Avoid calling DaoAuthenticationProvider on every request, which calls BCryptPasswordEncoder every time and causes
+  performance problems.
 - feature: The role mapping and signup behavior can now be configured individually for each OAuth provider.
 - upgraded org.springframework.boot:spring-boot-starter-parent from 3.3.0 to 3.3.2
 - upgraded io.jsonwebtoken:jjwt-api from 0.12.5 to 0.12.6
@@ -28,8 +36,10 @@
 
 ## Version `2.6.0`
 
-- Feature: Updating the roles of a user or deleting a hole user object is only allowed, if after the request a user with at least one admin role remains in the system. (see [MIGRATION.md](MIGRATION.md))
-- Feature: LDAP-Authentication - Enable Group Subtree Search, introduced environment variable `APP_AUTH_LDAP_GROUP_SEARCH_SUBTREE` (see [MIGRATION.md](MIGRATION.md)) 
+- Feature: Updating the roles of a user or deleting a hole user object is only allowed, if after the request a user with
+  at least one admin role remains in the system. (see [MIGRATION.md](MIGRATION.md))
+- Feature: LDAP-Authentication - Enable Group Subtree Search, introduced environment variable
+  `APP_AUTH_LDAP_GROUP_SEARCH_SUBTREE` (see [MIGRATION.md](MIGRATION.md))
 - upgraded io.sentry:sentry-spring-boot-starter-jakarta from 7.6.0 to 7.10.0
 - upgraded org.springframework.boot:spring-boot-starter-parent from 3.2.4 to 3.3.0
 - upgraded org.flywaydb:flyway-core and org.flywaydb:flyway-database-postgresql from 10.11.0 to 10.15.0
@@ -40,18 +50,21 @@
 
 ## Version `2.5.14`
 
-- revert `The FallbackResourceResolver has been removed. URL paths that do not exist are no longer responded to with a DefaultSuccessPage.` 
+- revert
+  `The FallbackResourceResolver has been removed. URL paths that do not exist are no longer responded to with a DefaultSuccessPage.`
 - upgraded com.nulab-inc:zxcvbn from 1.8.2 to 1.9.0
 
 ## Version `2.5.13`
 
-- Fix: Boolean logic for parsing OIDC attributes corrected. Last name and first name were not correctly separated and assigned.
+- Fix: Boolean logic for parsing OIDC attributes corrected. Last name and first name were not correctly separated and
+  assigned.
 - Fix: Deletion of obsolete rights failed on application start if the right was assigned to a role
 - Fix: NotAllowedException during RightInitialization (see [MIGRATION.md](MIGRATION.md))
 - Fix: An expired but still existing SessionToken throws an Internal Server Error (HTTP 500)
 - Fix: Role-Initialization failed if no default role was defined in the application.yaml
 - Documentation and messages on password security improved
-- The FallbackResourceResolver has been removed. URL paths that do not exist are no longer responded to with a DefaultSuccessPage.
+- The FallbackResourceResolver has been removed. URL paths that do not exist are no longer responded to with a
+  DefaultSuccessPage.
 - Make JPA-Table-Name-Style configurable, Allow disabling Upper-Case-Table-Names. Default is Upper-Case-Table-Names.
 - upgraded org.springframework.boot:spring-boot-starter-parent from 3.2.3 to 3.2.4
 - upgraded com.unboundid:unboundid-ldapsdk from 6.0.11 to 7.0.0
@@ -65,15 +78,15 @@
 - upgraded org.eclipse.angus:jakarta.mail from 2.0.2 to 2.0.3
 - fix: prevent clearing the roles of a user during patch update
 - OAuth2:
-  - added Support for additional redirect URI after successful login
-  - added `allowed-redirect-urls` to `application.yaml` to define allowed redirect URLs
-  - fixed name mapping for OAuth2-Users
+    - added Support for additional redirect URI after successful login
+    - added `allowed-redirect-urls` to `application.yaml` to define allowed redirect URLs
+    - fixed name mapping for OAuth2-Users
 
 ## Version `2.5.11`
 
 - upgraded org.springframework.boot:spring-boot-starter-parent from 3.2.2 to 3.2.3
-  - previously pinned org.springframework.security:spring-security-core to 6.2.2 due to CVE-2024-22234, now unpinned
-  - previously pinned ch.qos.logback:logback-classic and ch.qos.logback:logback-core to 1.5.0, now unpinned
+    - previously pinned org.springframework.security:spring-security-core to 6.2.2 due to CVE-2024-22234, now unpinned
+    - previously pinned ch.qos.logback:logback-classic and ch.qos.logback:logback-core to 1.5.0, now unpinned
 - upgraded org.wiremock:wiremock-standalone from 3.4.1 to 3.4.2
 - upgraded io.sentry:sentry-spring-boot-starter-jakarta from 7.3.0 to 7.4.0
 
@@ -86,7 +99,8 @@
 - upgraded org.wiremock:wiremock-standalone from 3.3.1 to 3.4.1
 - upgraded ch.qos.logback:logback-classic from 1.4.14 to 1.5.0
 - upgraded ch.qos.logback:logback-core from 1.4.14 to 1.5.0
-- pinned org.springframework.security:spring-security-core to 6.2.2 due to CVE-2024-22234, will be unpinned as soon as a new version of spring-boot-starter-parent is available 
+- pinned org.springframework.security:spring-security-core to 6.2.2 due to CVE-2024-22234, will be unpinned as soon as a
+  new version of spring-boot-starter-parent is available
 
 ## Version `2.5.9`
 
@@ -124,7 +138,8 @@
 ## Version `2.5.4`
 
 - upgraded org.springframework.boot:spring-boot-starter-parent from 3.2.1 to 3.2.2
-  - :warning: Due to a changed error handling of `HandlerMethodValidationException` on the part of Spring Boot, the notes in the migration guide must be observed. See [MIGRATION.md](MIGRATION.md) for more information.
+    - :warning: Due to a changed error handling of `HandlerMethodValidationException` on the part of Spring Boot, the
+      notes in the migration guide must be observed. See [MIGRATION.md](MIGRATION.md) for more information.
 - Multi-Language-Support for Error-Messages
 
 ## Version `2.5.3`
@@ -139,11 +154,16 @@
 
 - Removed deprecated `Model.class`
 - Removed deprecated `NativeIdModel.class`
-- Removed deprecated `InvalidCredentialsException.class`. Use one of the known subclasses of AuthenticationException instead. See https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/core/AuthenticationException.html
-- Removed deprecated `UnauthorizedException.class`. Use one of the known subclasses of AuthenticationException instead. See https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/core/AuthenticationException.html
-- Removed deprecated `CurrentUserController.class` which forwarded all requests to `/v1/me/*` to `/v1/users/me/*` for backward compatibility reasons.
+- Removed deprecated `InvalidCredentialsException.class`. Use one of the known subclasses of AuthenticationException
+  instead.
+  See https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/core/AuthenticationException.html
+- Removed deprecated `UnauthorizedException.class`. Use one of the known subclasses of AuthenticationException instead.
+  See https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/core/AuthenticationException.html
+- Removed deprecated `CurrentUserController.class` which forwarded all requests to `/v1/me/*` to `/v1/users/me/*` for
+  backward compatibility reasons.
 - Removed `spring-boot-starter-hateoas` dependency from base library. See Migration Guide for more information.
-- Introduced `@ExposesEntity` annotation to replace `@ExposesResourceFor` (`spring-boot-starter-hateoas`) annotation. See Migration Guide for more information.
+- Introduced `@ExposesEntity` annotation to replace `@ExposesResourceFor` (`spring-boot-starter-hateoas`) annotation.
+  See Migration Guide for more information.
 - fix `/auth/renew` endpoint (CSRF)
 - upgraded org.apache.maven.plugins:maven-surefire-plugin from 3.2.3 to 3.2.5
 - upgraded org.apache.maven.plugins:maven-failsafe-plugin from 3.2.3 to 3.2.5
@@ -153,9 +173,11 @@
 
 - upgraded net.sf.okapi.lib:okapi-lib-xliff2 from 1.45.0 to 1.46.0
 - Database dependencies removed from base library. See Migration Guide for more information.
-- Users can now be assigned to multiple roles. The rights of the user result from the sum of the rights of the assigned roles.
+- Users can now be assigned to multiple roles. The rights of the user result from the sum of the rights of the assigned
+  roles.
 - Roles and Users can now be created via environment variables. For more information see [MIGRATION.md](MIGRATION.md)
-- With regard to the environment variables, the previous root element 'essencium-backend' has been renamed to 'essencium'. For more information see [MIGRATION.md](MIGRATION.md)
+- With regard to the environment variables, the previous root element 'essencium-backend' has been renamed to '
+  essencium'. For more information see [MIGRATION.md](MIGRATION.md)
 
 ## Version `2.4.11`
 
@@ -171,8 +193,12 @@
 - bump org.hibernate.orm:hibernate-jpamodelgen from 6.4.0.Final to 6.4.1.Final
 - bump io.sentry:sentry-spring-boot-starter-jakarta from 7.0.0 to 7.1.0
 - fix HTTP-Error 500 if an expired refresh token is used to renew an access token
-- Deprecated `UnauthorizedException`. Use implementations of `org.springframework.security.core.AuthenticationException` (https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/core/AuthenticationException.html) instead.
-- Deprecated `InvalidCredentialsException`. Use implementations of `org.springframework.security.core.AuthenticationException` (https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/core/AuthenticationException.html) instead.
+- Deprecated `UnauthorizedException`. Use implementations of
+  `org.springframework.security.core.AuthenticationException` (https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/core/AuthenticationException.html)
+  instead.
+- Deprecated `InvalidCredentialsException`. Use implementations of
+  `org.springframework.security.core.AuthenticationException` (https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/core/AuthenticationException.html)
+  instead.
 - switch to `devnull@frachtwerk.de` as default admin user
 
 ## Version `2.4.9`
@@ -190,16 +216,20 @@
 
 - upgraded org.hibernate.orm:hibernate-jpamodelgen from 6.3.1.Final to 6.4.0.Final
 - Introduction of the APP_DOMAIN environment variable:
-  - APP_DOMAIN is used to set the domain of the cookies. APP_DOMAIN contains only the domain without protocol and port (`localhost`).
-  - APP_URL is used for branding and redirects. APP_URL contains the protocol, domain and port (`http://localhost:8098`).
-  - This change reverts the change of version `2.4.7` and introduces a new environment variable.
+    - APP_DOMAIN is used to set the domain of the cookies. APP_DOMAIN contains only the domain without protocol and
+      port (`localhost`).
+    - APP_URL is used for branding and redirects. APP_URL contains the protocol, domain and port (
+      `http://localhost:8098`).
+    - This change reverts the change of version `2.4.7` and introduces a new environment variable.
 
 ## Version `2.4.7`
 
 - upgraded io.jsonwebtoken:jjwt-* from 0.12.2 to 0.12.3
-  - several changes to internal methods for token generation
-  - RefreshToken: In addition to the existing `accessToken`, a `refreshToken` is introduced. This is only required for the creation of further `accessToken` at the `/renew` endpoint. The `refreshToken` is set as a cookie that is only permitted for use at the refresh endpoint.
-  - Users receive an email notification on every new login.
+    - several changes to internal methods for token generation
+    - RefreshToken: In addition to the existing `accessToken`, a `refreshToken` is introduced. This is only required for
+      the creation of further `accessToken` at the `/renew` endpoint. The `refreshToken` is set as a cookie that is only
+      permitted for use at the refresh endpoint.
+    - Users receive an email notification on every new login.
 - upgraded org.jacoco:jacoco-maven-plugin from 0.8.10 to 0.8.11
 - upgraded io.sentry:sentry-spring-boot-starter-jakarta from 6.31.0 to 6.34.0
 - upgraded org.apache.maven.plugins:maven-failsafe-plugin from 3.1.2 to 3.2.2
@@ -234,11 +264,11 @@
 
 - new maven structure (parent pom, child pom's for each module)
 - dependency upgrades:
-  - spring-boot: `3.1.3` -> `3.1.4` 
-  - maven-javadoc-plugin: `3.5.0` -> `3.6.0`
-  - flyway-core: `9.19.4` -> `9.22.2`
-  - unboudid-ldapsdk: `6.0.9` -> `6.0.10`
-  - hibernate-jpamodelgen: `6.2.7.Final` -> `6.3.1.Final`
+    - spring-boot: `3.1.3` -> `3.1.4`
+    - maven-javadoc-plugin: `3.5.0` -> `3.6.0`
+    - flyway-core: `9.19.4` -> `9.22.2`
+    - unboudid-ldapsdk: `6.0.9` -> `6.0.10`
+    - hibernate-jpamodelgen: `6.2.7.Final` -> `6.3.1.Final`
 
 ## Version `2.4.3`
 
@@ -406,9 +436,9 @@
 ## Version `2.2.5`
 
 - Upgraded Spring Boot from `3.1.0` to `3.1.2`
-  - fixes CVE-2023-34036 (spring-hateoas)
-  - fixes CVE-2023-34034 (spring-security-web & spring-security-config)
-  - fixes CVE-2023-34035 (spring-security-config)
+    - fixes CVE-2023-34036 (spring-hateoas)
+    - fixes CVE-2023-34034 (spring-security-web & spring-security-config)
+    - fixes CVE-2023-34035 (spring-security-config)
 - Upgraded `io.sentry:sentry-spring-boot-starter-jakarta` from `6.25.0` to `6.25.2`
 - Upgraded `com.lazerycode.jmeter:jmeter-maven-plugin` from `3.7.0` to `3.8.0`
 
@@ -460,7 +490,8 @@
   see https://git.frachtwerk.de/web-starter/backend/-/issues/128)
 - init `getAllowedMethods()` in AccessAwareController. This method provides a default set of allowed
   HTTP-Methods and can be overridden if needed. By default, the following methods are offered in the OPTIONS
-  request: `HttpMethod.GET, HttpMethod.HEAD, HttpMethod.POST, HttpMethod.PUT, HttpMethod.PATCH, HttpMethod.DELETE, HttpMethod.OPTIONS` (
+  request:
+  `HttpMethod.GET, HttpMethod.HEAD, HttpMethod.POST, HttpMethod.PUT, HttpMethod.PATCH, HttpMethod.DELETE, HttpMethod.OPTIONS` (
   see https://git.frachtwerk.de/web-starter/backend/-/issues/177)
 
 ## Version `2.0.8`
@@ -655,7 +686,8 @@ essencium-backend:
 - support for additional Types in Converter (several time formats like `Calender`, `TimeStamp`)
 -
 
-Introduced `SpecificationBuilder` (`Specification<Customer> spec = SpecificationBuilder.specification(CustomerByOrdersSpec.class).withParams("orderItem", "Pizza").build();`)
+Introduced `SpecificationBuilder` (
+`Specification<Customer> spec = SpecificationBuilder.specification(CustomerByOrdersSpec.class).withParams("orderItem", "Pizza").build();`)
 
 - swagger support improved
 - introduced `OnTypeMismatch.IGNORE`
@@ -693,7 +725,8 @@ permissions are specified, they are OR-linked, so only one of them must be true.
 
 In case such permissions should be AND-linked and in particular the permissions of another controller method (different
 controller) should also be checked, the `AccessAwareSpecArgResolver` provides the new
-method `getRestrictionSpec(MethodParameter parameter, NativeWebRequest webRequest, List<Specification<Object>> baseList)`.
+method
+`getRestrictionSpec(MethodParameter parameter, NativeWebRequest webRequest, List<Specification<Object>> baseList)`.
 You get a specification with which for example the service method `existsFiltered(Specification spec)` can set the
 access to further objects as a condition.
 

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/advice/RestExceptionHandler.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/advice/RestExceptionHandler.java
@@ -113,7 +113,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
         errorAttributes.getErrorAttributes(request, ErrorAttributeOptions.defaults());
     attributes.put("timestamp", LocalDateTime.now());
     attributes.put("error", ex.getMessage());
-    attributes.put("message", "");
+    attributes.put("message", ex.getMessage());
     attributes.put("path", path);
 
     return new ResponseEntity<>(

--- a/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/advice/RestExceptionHandlerTest.java
+++ b/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/advice/RestExceptionHandlerTest.java
@@ -1,0 +1,81 @@
+package de.frachtwerk.essencium.backend.test.integration.controller.advice;
+
+import static de.frachtwerk.essencium.backend.test.integration.util.TestingUtils.ADMIN_PASSWORD;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import de.frachtwerk.essencium.backend.controller.advice.RestExceptionHandler;
+import de.frachtwerk.essencium.backend.test.integration.IntegrationTestApplication;
+import de.frachtwerk.essencium.backend.test.integration.util.TestingUtils;
+import jakarta.servlet.ServletContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest(
+    classes = IntegrationTestApplication.class,
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("local_integration_test")
+class RestExceptionHandlerTest {
+
+  @Autowired private WebApplicationContext webApplicationContext;
+
+  @Autowired private MockMvc mockMvc;
+
+  @Autowired private TestingUtils testingUtils;
+
+  private String accessTokenAdmin;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    accessTokenAdmin =
+        testingUtils.createAccessToken(testingUtils.createAdminUser(), mockMvc, ADMIN_PASSWORD);
+  }
+
+  @Test
+  @DisplayName("Test for the existence of a Rest Exception Handler")
+  void restExceptionHandlerExistenceTest() {
+    ServletContext servletContext = webApplicationContext.getServletContext();
+    assertThat(servletContext).isInstanceOf(MockServletContext.class);
+    assertThat(webApplicationContext.getBean("restExceptionHandler"))
+        .isNotNull()
+        .isInstanceOf(RestExceptionHandler.class);
+  }
+
+  @Nested
+  @DisplayName("Property Reference Exception Tests")
+  class PropertyReferenceExceptionTest {
+
+    @Test
+    @DisplayName("Valid sort query parameter causes no exception")
+    void noPropertyReferenceExceptionTest() throws Exception {
+      mockMvc
+          .perform(
+              get("/v1/users?sort=email").header("Authorization", "Bearer " + accessTokenAdmin))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.totalElements", is(2)));
+    }
+
+    @Test
+    @DisplayName("Invalid sort query parameter causes exception")
+    void proeprtyReferenceExceptionTest() throws Exception {
+      mockMvc
+          .perform(
+              get("/v1/users?sort=invalid").header("Authorization", "Bearer " + accessTokenAdmin))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.error", is("No property 'invalid' found for type 'TestUser'")));
+    }
+  }
+}

--- a/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/advice/RestExceptionHandlerTest.java
+++ b/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/advice/RestExceptionHandlerTest.java
@@ -65,12 +65,12 @@ class RestExceptionHandlerTest {
           .perform(
               get("/v1/users?sort=email").header("Authorization", "Bearer " + accessTokenAdmin))
           .andExpect(status().isOk())
-          .andExpect(jsonPath("$.totalElements", is(2)));
+          .andExpect(jsonPath("$.pageable.sort.sorted", is(true)));
     }
 
     @Test
     @DisplayName("Invalid sort query parameter causes exception")
-    void proeprtyReferenceExceptionTest() throws Exception {
+    void propertyReferenceExceptionTest() throws Exception {
       mockMvc
           .perform(
               get("/v1/users?sort=invalid").header("Authorization", "Bearer " + accessTokenAdmin))


### PR DESCRIPTION
Implemented an exception handler to handle PropertyReferenceException caused by an invalid value in the `sort` query parameter. Previous behaviour resulted in an `Internal Error 500` response with a full trace of the exception. Now the API will respond with the error format used for reporting other errors (e.g Unauthorized) and omits the exception trace thus resulting in a more clear and user-friendly response.

*Note:* Invalid values for the other query parameters - page and size, are handled with an OK response from the server and a json containing results for the request with the invalid values substituted by default valid. In order to keep the invalid query handling consistent, the initial idea was to filter the `sort` parameter for invalid values and in case of such present to return an unsorted response.
This could be achieved with reflection and matching `sort` parameter with defined fields of the java object. However since the Pageable interface is used to transmit the query parameters, the Pageable object annot be edited in a pre-processing function to remove invalid sort values and pass a new Pageable with only valid values and thus avoid the PropertyReferenceException. The only option is to construct a `SimplePageRequest` which implements `Pageable` with the edited sort values and pass it on. This however breaks the Dependency Inversion principle and should be avoided.
Therefore, at this point no solution will be implemented to handles the sort parameter like the other two and we will resolve to an ExceptionHandler.

fixes #390