### PR TITLE
chore: add common interface for AbstractBaseUser and EssenciumUserDet…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Version `3.3.0-SNAPSHOT`
+
+### 🌟 Features
+
+- Add `BaseEssenciumUserDetails` as common interface for `EssenciumUserDetails` and `BaseUserDetails`.
+
+### 🐞 Bug Fixes
+
 ## Version `3.2.0`
 
 ⚠️ **Breaking Change** ⚠️

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/AbstractBaseUser.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/AbstractBaseUser.java
@@ -171,14 +171,6 @@ public abstract class AbstractBaseUser<ID extends Serializable> extends Abstract
   }
 
   @Override
-  public Object getAdditionalClaimByKey(String key) {
-    if (Objects.isNull(getAdditionalClaims())
-        || getAdditionalClaims().isEmpty()
-        || Objects.isNull(key)) return null;
-    return getAdditionalClaims().get(key);
-  }
-
-  @Override
   public Map<String, Object> getAdditionalClaims() {
     return Map.of();
   }

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/dto/BaseEssenciumUserDetails.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/dto/BaseEssenciumUserDetails.java
@@ -22,6 +22,7 @@ package de.frachtwerk.essencium.backend.model.dto;
 import java.io.Serializable;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -40,7 +41,40 @@ public interface BaseEssenciumUserDetails<ID extends Serializable> extends UserD
 
   Map<String, Object> getAdditionalClaims();
 
-  Object getAdditionalClaimByKey(String key);
+  /**
+   * Get additional claim by key.
+   *
+   * @param key the key of the additional claim
+   * @return the additional claim value, or null if not found as Object
+   */
+  default Object getAdditionalClaimByKey(String key) {
+    if (Objects.isNull(getAdditionalClaims())
+        || getAdditionalClaims().isEmpty()
+        || Objects.isNull(key)) return null;
+    return getAdditionalClaims().get(key);
+  }
+
+  /**
+   * Get additional claim by key and try to convert it to the specified class.
+   *
+   * <p>Currently supports conversion to Long, Integer, String, and Boolean. For other types it will
+   * return the original object if it is assignable to the specified class.
+   *
+   * @param key the key of the additional claim
+   * @param clazz the class to convert to (the type of the additional claim)
+   * @return the additional claim value converted to the specified class, or null if not found
+   */
+  default <O> O getAdditionalClaimByKey(String key, Class<O> clazz) {
+    Object object = getAdditionalClaims().get(key);
+    if (object == null) {
+      return null;
+    } else if (clazz.isAssignableFrom(object.getClass())) {
+      return clazz.cast(object);
+    } else if (object instanceof Number number) {
+      return clazz.cast(number.longValue());
+    }
+    return (O) object;
+  }
 
   ID getId();
 }

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/dto/EssenciumUserDetails.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/dto/EssenciumUserDetails.java
@@ -97,36 +97,4 @@ public class EssenciumUserDetails<ID extends Serializable>
       default -> id;
     };
   }
-
-  /**
-   * Get additional claim by key.
-   *
-   * @param key the key of the additional claim
-   * @return the additional claim value, or null if not found as Object
-   */
-  public Object getAdditionalClaimByKey(String key) {
-    return additionalClaims.get(key);
-  }
-
-  /**
-   * Get additional claim by key and try to convert it to the specified class.
-   *
-   * <p>Currently supports conversion to Long, Integer, String, and Boolean. For other types it will
-   * return the original object if it is assignable to the specified class.
-   *
-   * @param key the key of the additional claim
-   * @param clazz the class to convert to (the type of the additional claim)
-   * @return the additional claim value converted to the specified class, or null if not found
-   */
-  public <O> O getAdditionalClaimByKey(String key, Class<O> clazz) {
-    Object object = getAdditionalClaims().get(key);
-    if (object == null) {
-      return null;
-    } else if (clazz.isAssignableFrom(object.getClass())) {
-      return clazz.cast(object);
-    } else if (object instanceof Number number) {
-      return clazz.cast(number.longValue());
-    }
-    return (O) object;
-  }
 }

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/dto/EssenciumUserDetails.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/dto/EssenciumUserDetails.java
@@ -39,7 +39,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 @Data
 @Getter
 @AllArgsConstructor
-public class EssenciumUserDetails<ID extends Serializable> implements UserDetails {
+public class EssenciumUserDetails<ID extends Serializable>
+    implements BaseEssenciumUserDetails<ID>, UserDetails {
   private final ID id;
   private final String username;
   private final String firstName;

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/model/dto/EssenciumUserDetailsTest.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/model/dto/EssenciumUserDetailsTest.java
@@ -25,8 +25,12 @@ import static org.mockito.Mockito.when;
 
 import de.frachtwerk.essencium.backend.model.AbstractBaseUser;
 import java.util.*;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.GrantedAuthority;
@@ -128,6 +132,30 @@ class EssenciumUserDetailsTest {
     assertNull(user.getAdditionalClaimByKey("nonexistent", Object.class));
     assertNull(user.getAdditionalClaimByKey("null"));
     assertNull(user.getAdditionalClaimByKey("nonexistent"));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void testGetAdditionalClaimByKey_NullSafe(Map<String, Object> claims, String key) {
+    EssenciumUserDetails<Long> user =
+        EssenciumUserDetails.<Long>builder()
+            .id(1L)
+            .username("")
+            .firstName("")
+            .lastName("")
+            .locale("")
+            .roles(Set.of())
+            .rights(Set.of())
+            .additionalClaims(claims)
+            .build();
+    assertNull(user.getAdditionalClaimByKey(key));
+  }
+
+  static Stream<Arguments> testGetAdditionalClaimByKey_NullSafe() {
+    return Stream.of(
+        Arguments.of(null, "anyKey"),
+        Arguments.of(Collections.emptyMap(), "anyKey"),
+        Arguments.of(Map.of("key", "claim"), null));
   }
 
   @Test


### PR DESCRIPTION
This PR adds a common interface to `AbstractBaseUser` and `EssenciumUserDetails`.
This will be useful when an application needs to perform permission checks both on the current user via `EssenciumUserDetails`, but also on arbitrary `User` entities from the database, as now the checks can operate on the common interface instead of having to be duplicated for both classes.