### PR TITLE
#864 fix: add missing @Transactional to @Modifying queries in ApiTokenRepository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   - `mail.new-login-mail.enabled` (default: `true`)
 
 ### 🐞 Bug Fixes
+* fix: add missing `@Transactional` to `@Modifying` queries in `ApiTokenRepository`
 
 ### 🔨 Dependency Upgrades
 

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/repository/ApiTokenRepository.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/repository/ApiTokenRepository.java
@@ -27,11 +27,13 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface ApiTokenRepository extends BaseRepository<ApiToken, UUID> {
   List<ApiToken> findAllByLinkedUser(String linkedUser);
 
+  @Transactional
   @Modifying
   @Query(
       "update ApiToken at set at.status = :status, at.validUntil = :validUntil where at.id = :id")
@@ -39,10 +41,12 @@ public interface ApiTokenRepository extends BaseRepository<ApiToken, UUID> {
 
   List<ApiToken> findAllByStatusAndValidUntilBefore(ApiTokenStatus status, LocalDate validUntil);
 
+  @Transactional
   @Modifying
   @Query("update ApiToken at set at.status = :status where at.id in :ids")
   void setStatusByIds(ApiTokenStatus status, List<UUID> ids);
 
+  @Transactional
   @Modifying
   @Query("delete from ApiToken at where at.validUntil < :validUntil")
   void deleteAllByValidUntilBefore(LocalDate validUntil);


### PR DESCRIPTION
## Description

`@Modifying` queries in `ApiTokenRepository` were missing `@Transactional` annotations.
Spring Data JPA requires `@Transactional` on modifying queries (UPDATE/DELETE),
otherwise an `InvalidDataAccessApiUsageException` is thrown at runtime.

This fix adds the missing annotations.

Closes #864

## Changes

- Added `@Transactional` to all `@Modifying` query methods in `ApiTokenRepository`
- Updated `CHANGELOG.md`