### PR TITLE
#870 fix: respect server.error.include-message configuration in ErrorResponse

### DIFF
--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/advice/RestExceptionHandler.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/advice/RestExceptionHandler.java
@@ -27,6 +27,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.web.ErrorProperties;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.web.error.ErrorAttributeOptions;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
@@ -46,10 +48,12 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @ControllerAdvice
 public class RestExceptionHandler extends ResponseEntityExceptionHandler {
   private final ErrorAttributes errorAttributes;
+  private final boolean includeMessage;
 
   @Autowired
-  public RestExceptionHandler(ErrorAttributes errorAttributes) {
+  public RestExceptionHandler(ErrorAttributes errorAttributes, ServerProperties serverProperties) {
     this.errorAttributes = errorAttributes;
+    this.includeMessage = serverProperties.getError().getIncludeMessage() != ErrorProperties.IncludeAttribute.NEVER;
   }
 
   @Override
@@ -73,7 +77,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     attributes.put("message", message);
     attributes.put("path", path);
 
-    return new ResponseEntity<>(new ErrorResponse(status.value(), attributes), status);
+    return new ResponseEntity<>(new ErrorResponse(status.value(), attributes, includeMessage), status);
   }
 
   @Override
@@ -103,7 +107,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     attributes.put("message", errors);
     attributes.put("path", path);
 
-    return new ResponseEntity<>(new ErrorResponse(status.value(), attributes), headers, status);
+    return new ResponseEntity<>(new ErrorResponse(status.value(), attributes, includeMessage), headers, status);
   }
 
   @ExceptionHandler(NotAllowedException.class)
@@ -120,7 +124,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     attributes.put("path", path);
 
     return new ResponseEntity<>(
-        new ErrorResponse(HttpStatus.FORBIDDEN.value(), attributes), HttpStatus.FORBIDDEN);
+        new ErrorResponse(HttpStatus.FORBIDDEN.value(), attributes, includeMessage), HttpStatus.FORBIDDEN);
   }
 
   @ExceptionHandler(DuplicateResourceException.class)
@@ -137,7 +141,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     attributes.put("path", path);
 
     return new ResponseEntity<>(
-        new ErrorResponse(HttpStatus.CONFLICT.value(), attributes), HttpStatus.CONFLICT);
+        new ErrorResponse(HttpStatus.CONFLICT.value(), attributes, includeMessage), HttpStatus.CONFLICT);
   }
 
   @ExceptionHandler(InvalidInputException.class)
@@ -154,6 +158,6 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     attributes.put("path", path);
 
     return new ResponseEntity<>(
-        new ErrorResponse(HttpStatus.BAD_REQUEST.value(), attributes), HttpStatus.BAD_REQUEST);
+        new ErrorResponse(HttpStatus.BAD_REQUEST.value(), attributes, includeMessage), HttpStatus.BAD_REQUEST);
   }
 }

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/dto/ErrorResponse.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/dto/ErrorResponse.java
@@ -22,8 +22,6 @@ package de.frachtwerk.essencium.backend.model.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Map;
 import lombok.Data;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.web.ErrorProperties;
 
 @Data
 public class ErrorResponse {
@@ -37,21 +35,13 @@ public class ErrorResponse {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private final Object errors;
 
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  @Value("${server.error.include-message}")
-  private ErrorProperties.IncludeAttribute includeMessageMode;
 
-  public ErrorResponse(int status, Map<String, Object> errorAttributes) {
+  public ErrorResponse(int status, Map<String, Object> errorAttributes, boolean includeMessage) {
     this.status = status;
     this.error = errorAttributes.get("error").toString();
-    this.message = includeMessage() ? errorAttributes.get("message") : "";
+    this.message = includeMessage ? errorAttributes.get("message") : null;
     this.errors = errorAttributes.get("errors");
     this.timestamp = errorAttributes.get("timestamp").toString();
     this.path = errorAttributes.get("path").toString();
-  }
-
-  private boolean includeMessage() {
-    return includeMessageMode == null
-        || includeMessageMode.equals(ErrorProperties.IncludeAttribute.ALWAYS);
   }
 }


### PR DESCRIPTION
### Solution
- Inject `ServerProperties` into `RestExceptionHandler`, which  is a Spring-managed bean
- Evaluate `includeMessage` once at construction time
- Pass the resolved `boolean` into the `ErrorResponse` constructor
- Remove the dead `@Value` field and `includeMessage()` method from  `ErrorResponse` entirely

### Changes
| File | Change |
|------|--------|
| `ErrorResponse.java` | Removed `@Value` field and `includeMessage()` method; constructor now accepts `boolean includeMessage` |
| `RestExceptionHandler.java` | Added `ServerProperties` constructor injection; passes `includeMessage` to all 5 `ErrorResponse` call sites |