### PR TITLE
fix(users): enforce ownership access control on terminate endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - fix: add missing `@Transactional` to `@Modifying` queries in `ApiTokenRepository` and `SessionTokenRepository` to ensure proper transaction handling.
 - Removed unnecessary `@Transactional` annotations from methods in EssenciumScheduler.
+- `POST /v1/users/{id}/terminate` now enforces ownership-based access control (`testAccess(spec)`) before fetching the target user, matching the pattern already used by `update`, `patch`, and `delete`. Previously, any user with `USER_UPDATE` could terminate sessions of any other user even when `@RestrictAccessToOwnedEntities` was configured.
 
 ### 🔨 Dependency Upgrades
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,19 @@
 # Migration Guide
 
+## Version `3.4.0`
+
+### Access-control change: `terminate` endpoint honours ownership specs
+
+`POST /v1/users/{id}/terminate` now runs `testAccess(spec)` before fetching the
+target user. Downstream projects that rely on ownership-based access control
+(e.g. `@RestrictAccessToOwnedEntities`) will see `terminate` start respecting
+those restrictions; projects relying on `@Secured` only (`USER_UPDATE`) are
+unaffected because `testAccess` returns the service unchanged when no ownership
+filter applies. No database schema change. No API shape change. Clients that
+were previously allowed to terminate another user's session will now receive a
+`ResourceNotFoundException` — the same response `delete` / `update` would have
+returned under the same conditions before this change.
+
 ## Version `3.3.0`
 
 ### UserUtil

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/AbstractUserController.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/AbstractUserController.java
@@ -360,7 +360,7 @@ public abstract class AbstractUserController<
   public void terminate(
       @PathVariable @NotNull final ID id,
       @Spec(path = "id", pathVars = "id", spec = Equal.class) @Parameter(hidden = true) SPEC spec) {
-    userService.terminate(super.service.getById(id).getUsername());
+    userService.terminate(super.service.testAccess(spec).getById(id).getUsername());
   }
 
   // Current user-related endpoints

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/LongUserControllerTest.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/LongUserControllerTest.java
@@ -192,13 +192,33 @@ class LongUserControllerTest {
     BaseUserSpec testSpecification = Mockito.mock(BaseUserSpec.class);
 
     UserStub userStubMock = mock(UserStub.class);
+    Mockito.when(userServiceMock.testAccess(testSpecification)).thenReturn(userServiceMock);
     when(userServiceMock.getById(testId)).thenReturn(userStubMock);
     when(userStubMock.getUsername()).thenReturn("user@example.com");
 
     testSubject.terminate(testId, testSpecification);
+    Mockito.verify(userServiceMock).testAccess(testSpecification);
     verify(userServiceMock).getById(testId);
     verify(userServiceMock).terminate("user@example.com");
     verifyNoMoreInteractions(userServiceMock);
+  }
+
+  @Test
+  void terminateDeniedByOwnershipSpecThrows() {
+    var testId = 42L;
+    BaseUserSpec testSpecification = Mockito.mock(BaseUserSpec.class);
+
+    // Ownership-based access control should reject termination of another user's
+    // session the same way testAccess rejects the other mutating endpoints.
+    Mockito.when(userServiceMock.testAccess(testSpecification))
+        .thenThrow(new ResourceNotFoundException());
+
+    org.junit.jupiter.api.Assertions.assertThrows(
+        ResourceNotFoundException.class,
+        () -> testSubject.terminate(testId, testSpecification));
+    Mockito.verify(userServiceMock).testAccess(testSpecification);
+    Mockito.verify(userServiceMock, Mockito.never()).getById(testId);
+    Mockito.verify(userServiceMock, Mockito.never()).terminate(Mockito.anyString());
   }
 
   @Test

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/UUIDUserControllerTest.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/UUIDUserControllerTest.java
@@ -191,12 +191,32 @@ class UUIDUserControllerTest {
     BaseUserSpec testSpecification = Mockito.mock(BaseUserSpec.class);
 
     TestUUIDUser userStubMock = mock(TestUUIDUser.class);
+    Mockito.when(userServiceMock.testAccess(testSpecification)).thenReturn(userServiceMock);
     when(userServiceMock.getById(testId)).thenReturn(userStubMock);
     when(userStubMock.getUsername()).thenReturn("user@example.com");
     testSubject.terminate(testId, testSpecification);
+    Mockito.verify(userServiceMock).testAccess(testSpecification);
     verify(userServiceMock).getById(testId);
     verify(userServiceMock).terminate("user@example.com");
     Mockito.verifyNoMoreInteractions(userServiceMock);
+  }
+
+  @Test
+  void terminateDeniedByOwnershipSpecThrows() {
+    var testId = UUID.randomUUID();
+    BaseUserSpec testSpecification = Mockito.mock(BaseUserSpec.class);
+
+    // Ownership-based access control should reject termination of another user's
+    // session the same way testAccess rejects the other mutating endpoints.
+    Mockito.when(userServiceMock.testAccess(testSpecification))
+        .thenThrow(new ResourceNotFoundException());
+
+    org.junit.jupiter.api.Assertions.assertThrows(
+        ResourceNotFoundException.class,
+        () -> testSubject.terminate(testId, testSpecification));
+    Mockito.verify(userServiceMock).testAccess(testSpecification);
+    Mockito.verify(userServiceMock, Mockito.never()).getById(testId);
+    Mockito.verify(userServiceMock, Mockito.never()).terminate(Mockito.anyString());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Closes #862. `POST /v1/users/{id}/terminate` received the `Spec` parameter for ownership-based access control but never used it, so any user with `USER_UPDATE` could terminate sessions of any other user even when `@RestrictAccessToOwnedEntities` was configured. Every other mutating endpoint in `AbstractUserController` (update, patch, delete, deleteToken, ...) routes through `service.testAccess(spec)` first. This PR brings `terminate` in line with that pattern.

## Change

`essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/AbstractUserController.java`:

```diff
   public void terminate(
       @PathVariable @NotNull final ID id,
       @Spec(path = "id", pathVars = "id", spec = Equal.class) @Parameter(hidden = true) SPEC spec) {
-    userService.terminate(super.service.getById(id).getUsername());
+    userService.terminate(super.service.testAccess(spec).getById(id).getUsername());
   }
```

The `delete` endpoint directly above at line 343 uses the same shape -- `service.testAccess(spec).deleteById(id)`. When `testAccess` rejects (ownership filter excludes the target user) it throws `ResourceNotFoundException`, which is the same response surface the other mutating endpoints already produce for the same scenario.

## Tests

Both controller test classes (`UUIDUserControllerTest`, `LongUserControllerTest`):

1. **Existing `terminate()` test** -- updated to stub `testAccess(spec)` and verify it's invoked. Without the stub the new chain call would hit a `NullPointerException` on the mock.

2. **New `terminateDeniedByOwnershipSpecThrows()` test** -- stubs `testAccess` to throw `ResourceNotFoundException`, asserts the exception propagates, and asserts `getById` / `terminate` are never reached. This is the regression pin that blocks the bug from coming back.

The `testAccess(spec).thenReturn(userServiceMock)` pattern is already used by the existing `update` / `patch` tests in both files (see UUIDUserControllerTest.java line 149), so the new setup mirrors established style.

## Docs

- **`CHANGELOG.md`** -- 3.4.0-SNAPSHOT "🐞 Bug Fixes" section gets a bullet describing the fix.
- **`MIGRATION.md`** -- new `Version 3.4.0` section explaining the downstream impact:
  - Projects using `@Secured` only (`USER_UPDATE`): unaffected.
  - Projects using `@RestrictAccessToOwnedEntities`: `terminate` will now respect the ownership restriction; clients that were previously allowed to terminate another user's session will now receive `ResourceNotFoundException` (same response `delete` / `update` would have returned under the same conditions).
  - No schema change, no API shape change.

## Scope note

Local Maven/Java is not installed in this workspace so the build wasn't run here. The diff is four lines of production code (one actual change + minor test-mock wiring) and the pattern is copied verbatim from the neighbouring `delete` endpoint, so the risk of a build regression is minimal -- but happy to iterate if CI surfaces anything.

Closes #862

---

This contribution was developed with AI assistance (Claude Code).
