### PR TITLE
#871 fix(security) : replace Random by SecureRandom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - fix: add missing `@Transactional` to `@Modifying` queries in `ApiTokenRepository` and `SessionTokenRepository` to ensure proper transaction handling.
 - Removed unnecessary `@Transactional` annotations from methods in EssenciumScheduler.
+- Fix predictable anti-enumeration delay generation by using SecureRandom instead of Random
 
 ### 🔨 Dependency Upgrades
 

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/ResetCredentialsController.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/ResetCredentialsController.java
@@ -28,7 +28,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
-import java.util.Random;
+import java.security.SecureRandom;
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -61,13 +61,13 @@ public class ResetCredentialsController<
     USERDTO extends BaseUserDto<ID>> {
 
   private final AbstractUserService<USER, AUTHUSER, ID, USERDTO> userService;
-  private final Random random;
+  private final SecureRandom secureRandom;
 
   @Autowired
   ResetCredentialsController(
       @NotNull final AbstractUserService<USER, AUTHUSER, ID, USERDTO> userService) {
     this.userService = userService;
-    random = new Random();
+    secureRandom = new SecureRandom();
   }
 
   @PostMapping("/reset-credentials")
@@ -76,7 +76,7 @@ public class ResetCredentialsController<
   public void requestResetToken(@RequestBody @NotNull final String username) {
     // to prevent user enumeration, we add a random delay between 0,8s and 3s.
     try {
-      Thread.sleep(random.nextInt(800, 3000));
+      Thread.sleep(secureRandom.nextInt(800, 3000));
     } catch (InterruptedException interruptedException) {
       Thread.currentThread().interrupt();
     }


### PR DESCRIPTION
This PR resolves issue #871 by replacing Random with SecureRandom for generating delays used in anti-enumeration