### PR TITLE
fix: prevent resource leak in translation file creation (#866)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Removed unnecessary `@Transactional` annotations from methods in EssenciumScheduler.
 - `POST /v1/users/{id}/terminate` now enforces ownership-based access control (`testAccess(spec)`) before fetching the target user, matching the pattern already used by `update`, `patch`, and `delete`. Previously, any user with `USER_UPDATE` could terminate sessions of any other user even when `@RestrictAccessToOwnedEntities` was configured.
 - Fix predictable anti-enumeration delay generation by using SecureRandom instead of Random
+- Fix resource leak when creating resource bundle translation files and preserve translation file exception causes.
 
 ### 🔨 Dependency Upgrades
 

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/translation/ResourceBundleTranslationFileCreator.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/translation/ResourceBundleTranslationFileCreator.java
@@ -79,19 +79,21 @@ public class ResourceBundleTranslationFileCreator implements TranslationFileCrea
               .map(
                   localeStringEntry -> {
                     final File tempLocaleFile;
-                    final FileOutputStream tempLocalFileStream;
                     try {
                       tempLocaleFile =
                           File.createTempFile(
                               "translation-" + localeStringEntry.getKey().toString(),
                               ".properties",
                               tempDir.toFile());
-                      tempLocalFileStream = new FileOutputStream(tempLocaleFile);
-                      tempLocalFileStream.write(localeStringEntry.getValue().getBytes());
-                      tempLocalFileStream.close();
+                      try (var tempLocalFileStream = new FileOutputStream(tempLocaleFile)) {
+                        tempLocalFileStream.write(localeStringEntry.getValue().getBytes());
+                      }
                       return tempLocaleFile;
                     } catch (IOException e) {
-                      throw new RuntimeException();
+                      throw new TranslationFileException(
+                          "Failed to create temporary translation file for locale "
+                              + localeStringEntry.getKey(),
+                          e);
                     }
                   })
               .toList();
@@ -106,12 +108,13 @@ public class ResourceBundleTranslationFileCreator implements TranslationFileCrea
             log.warn(
                 "failed to add file {} to archive {}",
                 file.getAbsolutePath(),
-                zipFile.getAbsoluteFile());
+                zipFile.getAbsoluteFile(),
+                ex);
           }
         }
       }
     } catch (IOException e) {
-      throw new TranslationFileException(e.getMessage());
+      throw new TranslationFileException("Failed to create global resource-bundle archive", e);
     }
 
     final byte[] zipBytes;
@@ -119,7 +122,8 @@ public class ResourceBundleTranslationFileCreator implements TranslationFileCrea
     try (var zipFileStream = new FileInputStream(zipFile)) {
       zipBytes = zipFileStream.readAllBytes();
     } catch (IOException e) {
-      throw new RuntimeException();
+      throw new TranslationFileException(
+          "Failed to read generated resource-bundle archive: " + zipFile.getAbsolutePath(), e);
     }
 
     return zipBytes;


### PR DESCRIPTION
Closes #866

### Acceptance criteria

- Managed `FileOutputStream` with try-with-resources.
- Added meaningful exception messages and preserved original causes.
- Used `TranslationFileException` consistently instead of `RuntimeException`.
- Updated `CHANGELOG.md`.
- Did not update `MIGRATION.md` because this fix does not require downstream changes.

### Tests

- Tests run: 556, Failures: 0, Errors: 0, Skipped: 0