### PR TITLE
fix: handle validation errors without arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 🐞 Bug Fixes
 
+- Prevent validation error handling from crashing when a validation error has no arguments.
 - fix: add missing `@Transactional` to `@Modifying` queries in `ApiTokenRepository` and `SessionTokenRepository` to ensure proper transaction handling.
 - Removed unnecessary `@Transactional` annotations from methods in EssenciumScheduler.
 - `POST /v1/users/{id}/terminate` now enforces ownership-based access control (`testAccess(spec)`) before fetching the target user, matching the pattern already used by `update`, `patch`, and `delete`. Previously, any user with `USER_UPDATE` could terminate sessions of any other user even when `@RestrictAccessToOwnedEntities` was configured.

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/advice/RestExceptionHandler.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/advice/RestExceptionHandler.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.error.ErrorAttributeOptions;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.context.MessageSourceResolvable;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -86,14 +87,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     List<String> errors =
         ex.getParameterValidationResults().stream()
             .flatMap(e -> e.getResolvableErrors().stream())
-            .map(
-                messageSourceResolvable -> {
-                  String message = messageSourceResolvable.getDefaultMessage();
-                  DefaultMessageSourceResolvable messageSourceResolvableArgument =
-                      (DefaultMessageSourceResolvable) messageSourceResolvable.getArguments()[0];
-                  String field = messageSourceResolvableArgument.getDefaultMessage();
-                  return String.format("%s %s", field, message);
-                })
+            .map(RestExceptionHandler::formatValidationError)
             .toList();
 
     Map<String, Object> attributes =
@@ -104,6 +98,22 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     attributes.put("path", path);
 
     return new ResponseEntity<>(new ErrorResponse(status.value(), attributes), headers, status);
+  }
+
+  static String formatValidationError(MessageSourceResolvable messageSourceResolvable) {
+    String message = messageSourceResolvable.getDefaultMessage();
+    Object[] arguments = messageSourceResolvable.getArguments();
+
+    if (arguments != null
+        && arguments.length > 0
+        && arguments[0] instanceof DefaultMessageSourceResolvable messageSourceResolvableArgument) {
+      String field = messageSourceResolvableArgument.getDefaultMessage();
+      if (field != null && !field.isBlank()) {
+        return String.format("%s %s", field, message);
+      }
+    }
+
+    return message;
   }
 
   @ExceptionHandler(NotAllowedException.class)

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/advice/RestExceptionHandlerTest.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/advice/RestExceptionHandlerTest.java
@@ -28,7 +28,7 @@ class RestExceptionHandlerTest {
 
   @Test
   void formatValidationErrorUsesFieldArgumentWhenPresent() {
-    var fieldArgument = new DefaultMessageSourceResolvable("name");
+    var fieldArgument = new DefaultMessageSourceResolvable(new String[] {"name"}, "name");
     var resolvable =
         new DefaultMessageSourceResolvable(
             new String[] {"validation.name"}, new Object[] {fieldArgument}, "must not be blank");

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/advice/RestExceptionHandlerTest.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/advice/RestExceptionHandlerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 Frachtwerk GmbH, Leopoldstraße 7C, 76133 Karlsruhe.
+ *
+ * This file is part of essencium-backend.
+ *
+ * essencium-backend is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * essencium-backend is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with essencium-backend. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.frachtwerk.essencium.backend.controller.advice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+
+class RestExceptionHandlerTest {
+
+  @Test
+  void formatValidationErrorUsesFieldArgumentWhenPresent() {
+    var fieldArgument = new DefaultMessageSourceResolvable("name");
+    var resolvable =
+        new DefaultMessageSourceResolvable(
+            new String[] {"validation.name"}, new Object[] {fieldArgument}, "must not be blank");
+
+    assertThat(RestExceptionHandler.formatValidationError(resolvable))
+        .isEqualTo("name must not be blank");
+  }
+
+  @Test
+  void formatValidationErrorFallsBackToMessageWhenArgumentsAreEmpty() {
+    var resolvable =
+        new DefaultMessageSourceResolvable(
+            new String[] {"validation.custom"}, new Object[0], "custom validation failed");
+
+    assertThat(RestExceptionHandler.formatValidationError(resolvable))
+        .isEqualTo("custom validation failed");
+  }
+
+  @Test
+  void formatValidationErrorFallsBackToMessageWhenArgumentsAreNull() {
+    var resolvable =
+        new DefaultMessageSourceResolvable(
+            new String[] {"validation.custom"}, null, "custom validation failed");
+
+    assertThat(RestExceptionHandler.formatValidationError(resolvable))
+        .isEqualTo("custom validation failed");
+  }
+}


### PR DESCRIPTION
## Summary
- Guard validation error formatting when a resolvable error has null or empty arguments.
- Fall back to the validation error default message instead of crashing the exception handler.
- Add regression coverage for field arguments, empty arguments, and null arguments.
- Update the changelog.

Fixes #867.

## Tests
- `git diff --check`

Note: I could not run the Maven test suite locally because this machine does not have Maven installed and only has Java 8/10, while this project requires Java 21.
