### PR TITLE
870 fix error include message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Version `3.x.x`
+
+### 🌟 Features
+
+### 🐞 Bug Fixes
+
+- Respect `server.error.include-message` configuration in `ErrorResponse`: the `message` field is now controlled by `ErrorProperties.IncludeAttribute` (`always`, `never`, `on_param`) instead of always being included. When excluded, the field is omitted from the JSON response entirely.
+
+### 🔨 Dependency Upgrades
+
+---
+
 ## Version `3.4.0`
 
 ⚠️ **Breaking Change** ⚠️

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/advice/RestExceptionHandler.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/advice/RestExceptionHandler.java
@@ -27,6 +27,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.web.ErrorProperties;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.web.error.ErrorAttributeOptions;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.context.MessageSourceResolvable;
@@ -47,10 +49,12 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @ControllerAdvice
 public class RestExceptionHandler extends ResponseEntityExceptionHandler {
   private final ErrorAttributes errorAttributes;
+  private final boolean includeMessage;
 
   @Autowired
-  public RestExceptionHandler(ErrorAttributes errorAttributes) {
+  public RestExceptionHandler(ErrorAttributes errorAttributes, ServerProperties serverProperties) {
     this.errorAttributes = errorAttributes;
+    this.includeMessage = serverProperties.getError().getIncludeMessage() != ErrorProperties.IncludeAttribute.NEVER;
   }
 
   @Override
@@ -74,7 +78,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     attributes.put("message", message);
     attributes.put("path", path);
 
-    return new ResponseEntity<>(new ErrorResponse(status.value(), attributes), status);
+    return new ResponseEntity<>(new ErrorResponse(status.value(), attributes, includeMessage), status);
   }
 
   @Override
@@ -97,7 +101,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     attributes.put("message", errors);
     attributes.put("path", path);
 
-    return new ResponseEntity<>(new ErrorResponse(status.value(), attributes), headers, status);
+    return new ResponseEntity<>(new ErrorResponse(status.value(), attributes, includeMessage), headers, status);
   }
 
   static String formatValidationError(MessageSourceResolvable messageSourceResolvable) {
@@ -130,7 +134,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     attributes.put("path", path);
 
     return new ResponseEntity<>(
-        new ErrorResponse(HttpStatus.FORBIDDEN.value(), attributes), HttpStatus.FORBIDDEN);
+        new ErrorResponse(HttpStatus.FORBIDDEN.value(), attributes, includeMessage), HttpStatus.FORBIDDEN);
   }
 
   @ExceptionHandler(DuplicateResourceException.class)
@@ -147,7 +151,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     attributes.put("path", path);
 
     return new ResponseEntity<>(
-        new ErrorResponse(HttpStatus.CONFLICT.value(), attributes), HttpStatus.CONFLICT);
+        new ErrorResponse(HttpStatus.CONFLICT.value(), attributes, includeMessage), HttpStatus.CONFLICT);
   }
 
   @ExceptionHandler(InvalidInputException.class)
@@ -164,6 +168,6 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     attributes.put("path", path);
 
     return new ResponseEntity<>(
-        new ErrorResponse(HttpStatus.BAD_REQUEST.value(), attributes), HttpStatus.BAD_REQUEST);
+        new ErrorResponse(HttpStatus.BAD_REQUEST.value(), attributes, includeMessage), HttpStatus.BAD_REQUEST);
   }
 }

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/advice/RestExceptionHandler.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/advice/RestExceptionHandler.java
@@ -48,6 +48,17 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 @ControllerAdvice
 public class RestExceptionHandler extends ResponseEntityExceptionHandler {
+  /**
+   * Standard Spring Boot error-attribute map keys. {@code error}, {@code message}, and {@code path}
+   * mirror the private {@code key} field of {@link ErrorAttributeOptions.Include}; {@code
+   * timestamp} is hardcoded in {@code DefaultErrorAttributes}.
+   */
+  private static final String ATTR_TIMESTAMP = "timestamp";
+
+  private static final String ATTR_ERROR = "error";
+  private static final String ATTR_MESSAGE = "message";
+  private static final String ATTR_PATH = "path";
+
   private final ErrorAttributes errorAttributes;
   private final ErrorProperties.IncludeAttribute includeMessageMode;
 
@@ -62,7 +73,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
       case ALWAYS -> true;
       case NEVER -> false;
       case ON_PARAM -> {
-        String param = request.getParameter("message");
+        String param = request.getParameter(ATTR_MESSAGE);
         yield param != null && !"false".equalsIgnoreCase(param);
       }
     };
@@ -84,10 +95,10 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
 
     Map<String, Object> attributes =
         errorAttributes.getErrorAttributes(request, ErrorAttributeOptions.defaults());
-    attributes.put("timestamp", LocalDateTime.now());
-    attributes.put("error", error);
-    attributes.put("message", message);
-    attributes.put("path", path);
+    attributes.put(ATTR_TIMESTAMP, LocalDateTime.now());
+    attributes.put(ATTR_ERROR, error);
+    attributes.put(ATTR_MESSAGE, message);
+    attributes.put(ATTR_PATH, path);
 
     return new ResponseEntity<>(
         new ErrorResponse(status.value(), attributes, shouldIncludeMessage(request)), status);
@@ -108,10 +119,10 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
 
     Map<String, Object> attributes =
         errorAttributes.getErrorAttributes(request, ErrorAttributeOptions.defaults());
-    attributes.put("timestamp", LocalDateTime.now());
-    attributes.put("error", ex.getMessage());
-    attributes.put("message", errors);
-    attributes.put("path", path);
+    attributes.put(ATTR_TIMESTAMP, LocalDateTime.now());
+    attributes.put(ATTR_ERROR, ex.getMessage());
+    attributes.put(ATTR_MESSAGE, errors);
+    attributes.put(ATTR_PATH, path);
 
     return new ResponseEntity<>(
         new ErrorResponse(status.value(), attributes, shouldIncludeMessage(request)),
@@ -143,10 +154,10 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
 
     Map<String, Object> attributes =
         errorAttributes.getErrorAttributes(request, ErrorAttributeOptions.defaults());
-    attributes.put("timestamp", LocalDateTime.now());
-    attributes.put("error", HttpStatus.FORBIDDEN.value());
-    attributes.put("message", ex.getMessage());
-    attributes.put("path", path);
+    attributes.put(ATTR_TIMESTAMP, LocalDateTime.now());
+    attributes.put(ATTR_ERROR, HttpStatus.FORBIDDEN.value());
+    attributes.put(ATTR_MESSAGE, ex.getMessage());
+    attributes.put(ATTR_PATH, path);
 
     return new ResponseEntity<>(
         new ErrorResponse(HttpStatus.FORBIDDEN.value(), attributes, shouldIncludeMessage(request)),
@@ -161,10 +172,10 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
 
     Map<String, Object> attributes =
         errorAttributes.getErrorAttributes(request, ErrorAttributeOptions.defaults());
-    attributes.put("timestamp", LocalDateTime.now());
-    attributes.put("error", HttpStatus.CONFLICT.value());
-    attributes.put("message", ex.getMessage());
-    attributes.put("path", path);
+    attributes.put(ATTR_TIMESTAMP, LocalDateTime.now());
+    attributes.put(ATTR_ERROR, HttpStatus.CONFLICT.value());
+    attributes.put(ATTR_MESSAGE, ex.getMessage());
+    attributes.put(ATTR_PATH, path);
 
     return new ResponseEntity<>(
         new ErrorResponse(HttpStatus.CONFLICT.value(), attributes, shouldIncludeMessage(request)),
@@ -179,10 +190,10 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
 
     Map<String, Object> attributes =
         errorAttributes.getErrorAttributes(request, ErrorAttributeOptions.defaults());
-    attributes.put("timestamp", LocalDateTime.now());
-    attributes.put("error", HttpStatus.BAD_REQUEST.value());
-    attributes.put("message", ex.getMessage());
-    attributes.put("path", path);
+    attributes.put(ATTR_TIMESTAMP, LocalDateTime.now());
+    attributes.put(ATTR_ERROR, HttpStatus.BAD_REQUEST.value());
+    attributes.put(ATTR_MESSAGE, ex.getMessage());
+    attributes.put(ATTR_PATH, path);
 
     return new ResponseEntity<>(
         new ErrorResponse(

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/advice/RestExceptionHandler.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/controller/advice/RestExceptionHandler.java
@@ -49,12 +49,23 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @ControllerAdvice
 public class RestExceptionHandler extends ResponseEntityExceptionHandler {
   private final ErrorAttributes errorAttributes;
-  private final boolean includeMessage;
+  private final ErrorProperties.IncludeAttribute includeMessageMode;
 
   @Autowired
   public RestExceptionHandler(ErrorAttributes errorAttributes, ServerProperties serverProperties) {
     this.errorAttributes = errorAttributes;
-    this.includeMessage = serverProperties.getError().getIncludeMessage() != ErrorProperties.IncludeAttribute.NEVER;
+    this.includeMessageMode = serverProperties.getError().getIncludeMessage();
+  }
+
+  private boolean shouldIncludeMessage(WebRequest request) {
+    return switch (includeMessageMode) {
+      case ALWAYS -> true;
+      case NEVER -> false;
+      case ON_PARAM -> {
+        String param = request.getParameter("message");
+        yield param != null && !"false".equalsIgnoreCase(param);
+      }
+    };
   }
 
   @Override
@@ -78,7 +89,8 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     attributes.put("message", message);
     attributes.put("path", path);
 
-    return new ResponseEntity<>(new ErrorResponse(status.value(), attributes, includeMessage), status);
+    return new ResponseEntity<>(
+        new ErrorResponse(status.value(), attributes, shouldIncludeMessage(request)), status);
   }
 
   @Override
@@ -101,7 +113,10 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     attributes.put("message", errors);
     attributes.put("path", path);
 
-    return new ResponseEntity<>(new ErrorResponse(status.value(), attributes, includeMessage), headers, status);
+    return new ResponseEntity<>(
+        new ErrorResponse(status.value(), attributes, shouldIncludeMessage(request)),
+        headers,
+        status);
   }
 
   static String formatValidationError(MessageSourceResolvable messageSourceResolvable) {
@@ -134,7 +149,8 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     attributes.put("path", path);
 
     return new ResponseEntity<>(
-        new ErrorResponse(HttpStatus.FORBIDDEN.value(), attributes, includeMessage), HttpStatus.FORBIDDEN);
+        new ErrorResponse(HttpStatus.FORBIDDEN.value(), attributes, shouldIncludeMessage(request)),
+        HttpStatus.FORBIDDEN);
   }
 
   @ExceptionHandler(DuplicateResourceException.class)
@@ -151,7 +167,8 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     attributes.put("path", path);
 
     return new ResponseEntity<>(
-        new ErrorResponse(HttpStatus.CONFLICT.value(), attributes, includeMessage), HttpStatus.CONFLICT);
+        new ErrorResponse(HttpStatus.CONFLICT.value(), attributes, shouldIncludeMessage(request)),
+        HttpStatus.CONFLICT);
   }
 
   @ExceptionHandler(InvalidInputException.class)
@@ -168,6 +185,8 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     attributes.put("path", path);
 
     return new ResponseEntity<>(
-        new ErrorResponse(HttpStatus.BAD_REQUEST.value(), attributes, includeMessage), HttpStatus.BAD_REQUEST);
+        new ErrorResponse(
+            HttpStatus.BAD_REQUEST.value(), attributes, shouldIncludeMessage(request)),
+        HttpStatus.BAD_REQUEST);
   }
 }

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/dto/ErrorResponse.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/dto/ErrorResponse.java
@@ -22,8 +22,6 @@ package de.frachtwerk.essencium.backend.model.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Map;
 import lombok.Data;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.web.ErrorProperties;
 
 @Data
 public class ErrorResponse {
@@ -37,21 +35,13 @@ public class ErrorResponse {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private final Object errors;
 
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  @Value("${server.error.include-message}")
-  private ErrorProperties.IncludeAttribute includeMessageMode;
 
-  public ErrorResponse(int status, Map<String, Object> errorAttributes) {
+  public ErrorResponse(int status, Map<String, Object> errorAttributes, boolean includeMessage) {
     this.status = status;
     this.error = errorAttributes.get("error").toString();
-    this.message = includeMessage() ? errorAttributes.get("message") : "";
+    this.message = includeMessage ? errorAttributes.get("message") : null;
     this.errors = errorAttributes.get("errors");
     this.timestamp = errorAttributes.get("timestamp").toString();
     this.path = errorAttributes.get("path").toString();
-  }
-
-  private boolean includeMessage() {
-    return includeMessageMode == null
-        || includeMessageMode.equals(ErrorProperties.IncludeAttribute.ALWAYS);
   }
 }

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/dto/ErrorResponse.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/dto/ErrorResponse.java
@@ -29,7 +29,7 @@ public class ErrorResponse {
   private final Integer status;
   private final String error;
 
-  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
   private final Object message;
 
   private final String timestamp;

--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/dto/ErrorResponse.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/model/dto/ErrorResponse.java
@@ -28,13 +28,15 @@ public class ErrorResponse {
 
   private final Integer status;
   private final String error;
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   private final Object message;
+
   private final String timestamp;
   private final String path;
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private final Object errors;
-
 
   public ErrorResponse(int status, Map<String, Object> errorAttributes, boolean includeMessage) {
     this.status = status;

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/advice/RestExceptionHandlerTest.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/controller/advice/RestExceptionHandlerTest.java
@@ -20,9 +20,27 @@
 package de.frachtwerk.essencium.backend.controller.advice;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import de.frachtwerk.essencium.backend.model.dto.ErrorResponse;
+import de.frachtwerk.essencium.backend.model.exception.NotAllowedException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.boot.autoconfigure.web.ErrorProperties;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.web.error.ErrorAttributeOptions;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.ServletWebRequest;
 
 class RestExceptionHandlerTest {
 
@@ -55,5 +73,53 @@ class RestExceptionHandlerTest {
 
     assertThat(RestExceptionHandler.formatValidationError(resolvable))
         .isEqualTo("custom validation failed");
+  }
+
+  static Stream<Arguments> includeMessageCases() {
+    return Stream.of(
+        Arguments.of(ErrorProperties.IncludeAttribute.ALWAYS, null, true),
+        Arguments.of(ErrorProperties.IncludeAttribute.NEVER, null, false),
+        Arguments.of(ErrorProperties.IncludeAttribute.ON_PARAM, null, false),
+        Arguments.of(ErrorProperties.IncludeAttribute.ON_PARAM, "true", true),
+        Arguments.of(ErrorProperties.IncludeAttribute.ON_PARAM, "false", false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("includeMessageCases")
+  void shouldIncludeMessage(
+      ErrorProperties.IncludeAttribute mode, String messageParam, boolean expectMessagePresent) {
+    ResponseEntity<Object> response = handleNotAllowedException(mode, messageParam);
+
+    Object message = ((ErrorResponse) response.getBody()).getMessage();
+    if (expectMessagePresent) {
+      assertThat(message).isNotNull();
+    } else {
+      assertThat(message).isNull();
+    }
+  }
+
+  private ResponseEntity<Object> handleNotAllowedException(
+      ErrorProperties.IncludeAttribute mode, String messageParam) {
+    ErrorAttributes errorAttributes = mock(ErrorAttributes.class);
+    Map<String, Object> attrs = new HashMap<>();
+    attrs.put("error", "Forbidden");
+    attrs.put("message", "not allowed");
+    attrs.put("path", "/test");
+    attrs.put("timestamp", "2026-01-01T00:00");
+    when(errorAttributes.getErrorAttributes(any(), any(ErrorAttributeOptions.class)))
+        .thenReturn(attrs);
+
+    ServerProperties serverProperties = new ServerProperties();
+    serverProperties.getError().setIncludeMessage(mode);
+
+    MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+    httpRequest.setRequestURI("/test");
+    if (messageParam != null) {
+      httpRequest.setParameter("message", messageParam);
+    }
+
+    return new RestExceptionHandler(errorAttributes, serverProperties)
+        .handleNotAllowedException(
+            new NotAllowedException("not allowed"), new ServletWebRequest(httpRequest));
   }
 }

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/model/dto/ErrorResponseTest.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/model/dto/ErrorResponseTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2026 Frachtwerk GmbH, Leopoldstraße 7C, 76133 Karlsruhe.
+ *
+ * This file is part of essencium-backend.
+ *
+ * essencium-backend is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * essencium-backend is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with essencium-backend. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.frachtwerk.essencium.backend.model.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ErrorResponseTest {
+
+  private static final Map<String, Object> ERROR_ATTRIBUTES =
+      new HashMap<>(
+          Map.of(
+              "error", "Bad Request",
+              "message", "validation failed",
+              "path", "/test/path",
+              "timestamp", LocalDateTime.of(2026, 1, 1, 0, 0),
+              "status", 400));
+
+  @Test
+  void messageIsIncludedWhenFlagIsTrue() {
+    ErrorResponse response = new ErrorResponse(400, ERROR_ATTRIBUTES, true);
+
+    assertThat(response.getMessage()).isEqualTo("validation failed");
+  }
+
+  @Test
+  void messageIsNullWhenFlagIsFalse() {
+    ErrorResponse response = new ErrorResponse(400, ERROR_ATTRIBUTES, false);
+
+    assertThat(response.getMessage()).isNull();
+  }
+
+  @Test
+  void messageIsAbsentFromJsonWhenNull() throws Exception {
+    ErrorResponse response = new ErrorResponse(400, ERROR_ATTRIBUTES, false);
+    String json = new ObjectMapper().writeValueAsString(response);
+
+    assertThat(json).doesNotContain("\"message\"");
+  }
+
+  @Test
+  void otherFieldsAreAlwaysPresent() {
+    ErrorResponse response = new ErrorResponse(400, ERROR_ATTRIBUTES, false);
+
+    assertThat(response.getStatus()).isEqualTo(400);
+    assertThat(response.getError()).isEqualTo("Bad Request");
+    assertThat(response.getPath()).isEqualTo("/test/path");
+    assertThat(response.getTimestamp()).isNotNull();
+  }
+}

--- a/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/RoleControllerIntegrationTest.java
+++ b/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/RoleControllerIntegrationTest.java
@@ -252,7 +252,8 @@ class RoleControllerIntegrationTest {
         .perform(
             delete("/v1/roles/" + assignedRole.getName())
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + this.accessToken))
-        .andExpect(status().isForbidden());
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").isNotEmpty());
 
     final var roleCountAfter = roleRepository.count();
     final var rightCountAfter = rightRepository.count();
@@ -298,7 +299,8 @@ class RoleControllerIntegrationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + this.accessToken)
                 .content(testRoleUpdateJson))
-        .andExpect(status().isForbidden());
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").isNotEmpty());
   }
 
   @Test
@@ -330,7 +332,8 @@ class RoleControllerIntegrationTest {
         .perform(
             delete("/v1/roles/" + testProtectedRole.getName())
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + this.accessToken))
-        .andExpect(status().isForbidden());
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").isNotEmpty());
 
     final var roleCountAfter = roleRepository.count();
     final var rightCountAfter = rightRepository.count();

--- a/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/UserControllerIntegrationTest.java
+++ b/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/UserControllerIntegrationTest.java
@@ -927,4 +927,65 @@ class UserControllerIntegrationTest {
           .andReturn();
     }
   }
+
+  @Nested
+  @SpringBootTest(
+      classes = IntegrationTestApplication.class,
+      webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+      properties = "server.error.include-message=on_param")
+  @AutoConfigureMockMvc
+  @ActiveProfiles("test_h2")
+  class IncludeMessageOnParam {
+
+    private final MockMvc mockMvc;
+    private final TestingUtils testingUtils;
+
+    private TestUser adminUser;
+    private String adminToken;
+
+    @Autowired
+    IncludeMessageOnParam(MockMvc mockMvc, TestingUtils testingUtils) {
+      this.mockMvc = mockMvc;
+      this.testingUtils = testingUtils;
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+      testingUtils.clearUsers();
+      testingUtils.clearRoles();
+      testingUtils.clearRights();
+      adminUser = testingUtils.createAdminUser();
+      adminToken = testingUtils.createAdminAccessToken(mockMvc);
+    }
+
+    @AfterEach
+    void tearDown() {
+      testingUtils.clearUsers();
+      testingUtils.clearRoles();
+      testingUtils.clearRights();
+    }
+
+    @Test
+    @DisplayName("ON_PARAM without ?message param: message is excluded")
+    void notAllowed_withoutMessageParam_messageIsExcluded() throws Exception {
+      mockMvc
+          .perform(
+              delete("/v1/users/" + adminUser.getId())
+                  .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken))
+          .andExpect(status().isForbidden())
+          .andExpect(jsonPath("$.message").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("ON_PARAM with ?message=true: message is included")
+    void notAllowed_withMessageParamTrue_messageIsIncluded() throws Exception {
+      mockMvc
+          .perform(
+              delete("/v1/users/" + adminUser.getId())
+                  .param("message", "true")
+                  .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken))
+          .andExpect(status().isForbidden())
+          .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+  }
 }

--- a/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/UserControllerIntegrationTest.java
+++ b/essencium-backend/src/testIntegration/java/de/frachtwerk/essencium/backend/test/integration/controller/UserControllerIntegrationTest.java
@@ -861,7 +861,8 @@ class UserControllerIntegrationTest {
             delete("/v1/users/" + adminUser.getId())
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenAdmin))
-        .andExpect(status().isForbidden());
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").isNotEmpty());
   }
 
   @Test

--- a/essencium-backend/src/testIntegration/resources/application.yaml
+++ b/essencium-backend/src/testIntegration/resources/application.yaml
@@ -19,6 +19,8 @@
 # otherwise you may experience errors like: Proxy error: Could not proxy request /api/hello from localhost:8080 to http://localhost:8088... (ECONNREFUSED).
 server:
   port: 8098
+  error:
+    include-message: always
 
 app:
   domain: localhost


### PR DESCRIPTION
This PR is based on #877 by @deepika1214 and adresses #870.

---

- Unit- and Integration-Tests have been added for the previous changes.
- `IncludeAttribute.ON_PARAM` is now handled as well
  - The properties used for tests now also include `server.error.include-message: always` to include messages by default
- empty `message`s are excluded from serialization