### PR TITLE
fix: reject null CRUD update inputs

### DIFF
--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/AbstractCrudService.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/AbstractCrudService.java
@@ -27,6 +27,7 @@ import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -184,7 +185,8 @@ public abstract class AbstractCrudService<
    */
   @NotNull
   public final <E extends DTO> T update(@NotNull final ID id, @NotNull final E entity) {
-    final var processedEntity = updatePreProcessing(id, entity);
+    final var processedEntity =
+        updatePreProcessing(id, Objects.requireNonNull(entity, "entity must not be null"));
 
     final var saved = repository.save(processedEntity);
 
@@ -205,7 +207,9 @@ public abstract class AbstractCrudService<
    */
   @NotNull
   public final T patch(@NotNull final ID id, @NotNull final Map<String, Object> fieldUpdates) {
-    final var toUpdate = patchPreProcessing(id, fieldUpdates);
+    final var toUpdate =
+        patchPreProcessing(
+            id, Objects.requireNonNull(fieldUpdates, "fieldUpdates must not be null"));
 
     final var saved = repository.save(toUpdate);
 

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/service/AbstractCrudServiceTest.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/service/AbstractCrudServiceTest.java
@@ -174,6 +174,13 @@ class AbstractCrudServiceTest {
   }
 
   @Test
+  void updateRejectsNullEntity() {
+    assertThatThrownBy(() -> testSubject.update(42L, (String) null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("entity must not be null");
+  }
+
+  @Test
   void patch() {
     var inputId = 42L;
     var inputMap = new HashMap<String, Object>();
@@ -191,6 +198,13 @@ class AbstractCrudServiceTest {
     assertThat(callMap.get("patchPostProcessing")).isSameAs(databaseEntity);
 
     Mockito.verify(repositoryMock, Mockito.times(1)).save(preProcessedEntity);
+  }
+
+  @Test
+  void patchRejectsNullFieldUpdates() {
+    assertThatThrownBy(() -> testSubject.patch(42L, (Map<String, Object>) null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("fieldUpdates must not be null");
   }
 
   @Test


### PR DESCRIPTION
## Summary

- reject null update DTOs before invoking update preprocessing
- reject null patch maps before invoking patch preprocessing
- add focused regression tests for both public CRUD boundaries

`@NotNull` documents the contract but does not enforce method-parameter validation on ordinary service calls unless Spring method validation is configured. These checks make the existing public contract fail fast with a clear message.

## Validation

- `git diff --check` passed
- local Maven test could not be run because this environment has neither `mvn` nor the repository's `mvnw`; GitHub Actions should provide the authoritative build/test result.

Related: #380
