### PR TITLE
ci: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release_and_deploy.yml
+++ b/.github/workflows/release_and_deploy.yml
@@ -21,6 +21,9 @@ on:
   push:
     tags:
       - "v*.*.*"
+  # Manual fallback: select the release tag (not a branch) as the ref when
+  # dispatching, since release creation and versioning derive from github.ref.
+  workflow_dispatch:
 
 concurrency:
   group: "${{ github.ref }}"

--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -30,9 +30,8 @@ RUN adduser -D user
 USER user
 
 # Kopiere extrahierte Layer aus dem Build-Container
+# (Spring Boot 4 erzeugt keine spring-boot-loader/snapshot-dependencies-Layer mehr)
 COPY --from=build /build/essencium-backend-development/target/extracted/dependencies/ ./
-COPY --from=build /build/essencium-backend-development/target/extracted/spring-boot-loader/ ./
-COPY --from=build /build/essencium-backend-development/target/extracted/snapshot-dependencies/ ./
 COPY --from=build /build/essencium-backend-development/target/extracted/application/ ./
 
 EXPOSE 8098

--- a/essencium-backend-development-uuid/Dockerfile
+++ b/essencium-backend-development-uuid/Dockerfile
@@ -27,9 +27,9 @@ RUN adduser -D user
 
 USER user
 
+# Spring Boot 4 no longer produces spring-boot-loader/snapshot-dependencies
+# layer content; the empty directories get dropped by upload-artifact.
 COPY /target/extracted/dependencies/ ./
-COPY /target/extracted/spring-boot-loader/ ./
-# COPY /target/extracted/snapshot-dependencies/ ./ # GitHub Actions does not support snapshot dependencies
 COPY /target/extracted/application/ ./
 
 EXPOSE 8098

--- a/essencium-backend-development/Dockerfile
+++ b/essencium-backend-development/Dockerfile
@@ -27,9 +27,9 @@ RUN adduser -D user
 
 USER user
 
+# Spring Boot 4 no longer produces spring-boot-loader/snapshot-dependencies
+# layer content; the empty directories get dropped by upload-artifact.
 COPY /target/extracted/dependencies/ ./
-COPY /target/extracted/spring-boot-loader/ ./
-# COPY /target/extracted/snapshot-dependencies/ ./ # GitHub Actions does not support snapshot dependencies
 COPY /target/extracted/application/ ./
 
 EXPOSE 8098


### PR DESCRIPTION
The v4.0.0 tag push never triggered the release workflow (tags created via GITHUB_TOKEN/UI don't trigger downstream workflows), leaving the published `frachtwerk/essencium-backend-demo:latest` Docker image stale since June — built before the curl fix (19aa820d), so its curl-based HEALTHCHECK makes containers unhealthy.

Two changes:

1. **`workflow_dispatch` trigger** for the release workflow as a manual fallback (dispatch from the release tag ref).
2. **Drop `COPY` of empty Spring Boot 4 layers** in the Dockerfiles: `jarmode=tools extract --layers` no longer emits content into `spring-boot-loader`/`snapshot-dependencies`. `upload-artifact` silently drops the empty directories, so the artifact-based docker builds (release, experimental) fail with `"/target/extracted/spring-boot-loader": not found` — this is exactly what broke the re-triggered v4.0.0 release run ([33638847315](https://github.com/Frachtwerk/essencium-backend/actions/runs/33638847315)). Verified against the working `:unstable` image: both layers are empty (4.1 kB) and no loader classes exist in the image.
